### PR TITLE
Omit mounted DMG images

### DIFF
--- a/scripts/darwin.sh
+++ b/scripts/darwin.sh
@@ -18,6 +18,11 @@ for disk in $DISKS; do
   mountpoint=`echo "$diskinfo" | get_key "Mount Point"`
   size=`echo "$diskinfo" | get_key "Total Size" | get_until_paren`
 
+  # Omit mounted DMG images
+  if [ "$description" == "Disk Image" ]; then
+    continue
+  fi
+
   echo "device: $device"
   echo "description: $description"
   echo "size: $size"


### PR DESCRIPTION
After some experimentation, all mounted DMG images seem to have a
description of "Disk Image".

For example:

	$ diskutil info /dev/disk3
		Device Identifier:        disk3
		Device Node:              /dev/disk3
		Whole:                    Yes
		Part of Whole:            disk3
		Device / Media Name:      Disk Image

		Volume Name:              Not applicable (no file
		system)

		Mounted:                  Not applicable (no file
		system)

		File System:              None

		Content (IOContent):
		GUID_partition_scheme
		OS Can Be Installed:      No
		Media Type:               Generic
		Protocol:                 Disk Image
		SMART Status:             Not Supported

		Total Size:               16.3 MB
		(16299008 Bytes) (exactly 31834 512-Byte-Units)
		Volume Free Space:        Not applicable (no file system)
		Device Block Size:        512 Bytes

		Read-Only Media:          Yes
		Read-Only Volume:         Not applicable (no file system)

		Device Location:          External
		Removable Media:          Yes
		Media Removal:            Software-Activated

		Virtual:                  Yes
		OS 9 Drivers:             No
		Low Level Format:         Not supported

The `Device / Media Name` property is read as the device description, so
a simple string comparison does the trick.

See https://github.com/resin-io/etcher/issues/193