### PR TITLE
Omit loop devices and CD/DVD drives in GNU/Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,11 @@ GNU/Linux
 		system: true
 	},
 	{
-		device: '/dev/sr0',
-		description: 'DVD+-RW GU90N',
-		size: '1024M',
+		device: '/dev/sdb',
+		description: 'DataTraveler 2.0',
+		size: '7.3G',
+		mountpoint: '/media/UNTITLED',
+		name: '/dev/sdb',
 		system: false
 	}
 ]

--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -11,6 +11,12 @@ function trim {
 DISKS="`lsblk -d --output NAME | ignore_first_line`"
 
 for disk in $DISKS; do
+
+  # Omit loop devices and CD/DVD drives
+  if [[ $disk == loop* ]] || [[ $disk == sr* ]]; then
+    continue
+  fi
+
   device="/dev/$disk"
   description=`lsblk -d $device --output MODEL | ignore_first_line`
   size=`lsblk -d $device --output SIZE | ignore_first_line | trim`


### PR DESCRIPTION
For consistency with the rest of the operating systems.