### PR TITLE
Escape double quotes inside YAML values

### DIFF
--- a/build/parse.js
+++ b/build/parse.js
@@ -47,6 +47,14 @@ module.exports = function(input) {
   }
   return _.compact(_.map(input.split(/\n\s*\n/), function(device) {
     var result;
+    device = _.chain(device).split('\n').map(function(line) {
+      return line.replace(/"/g, function(match, index, string) {
+        if (_.any([string.indexOf('"') === index, string.lastIndexOf('"') === index])) {
+          return match;
+        }
+        return '\\"';
+      });
+    }).join('\n').value();
     result = yaml.safeLoad(device);
     if (_.isString(result)) {
       return _.object([result], [null]);

--- a/lib/parse.coffee
+++ b/lib/parse.coffee
@@ -38,6 +38,20 @@ yaml = require('js-yaml')
 module.exports = (input) ->
 	return {} if _.isEmpty(_.str.trim(input))
 	return _.compact _.map input.split(/\n\s*\n/), (device) ->
+
+		device = _.chain(device)
+			.split('\n')
+			.map (line) ->
+				return line.replace /"/g, (match, index, string) ->
+					if _.any [
+						string.indexOf('"') is index
+						string.lastIndexOf('"') is index
+					]
+						return match
+					return '\\"'
+			.join('\n')
+			.value()
+
 		result = yaml.safeLoad(device)
 		if _.isString(result)
 			return _.object([ result ], [ null ])

--- a/tests/parse.spec.coffee
+++ b/tests/parse.spec.coffee
@@ -138,3 +138,19 @@ describe 'Parse:', ->
 		.to.deep.equal [
 			'hello world': null
 		]
+
+	it 'should handle a double quote inside a value', ->
+		m.chai.expect parse '''
+			description: "SAMSUNG SSD PM810 2.5" 7mm 256GB"
+		'''
+		.to.deep.equal [
+			description: 'SAMSUNG SSD PM810 2.5" 7mm 256GB'
+		]
+
+	it 'should handle multiple double quotes inside a value', ->
+		m.chai.expect parse '''
+			description: "SAMSUNG "SSD" PM810 2.5" 7mm 256GB"
+		'''
+		.to.deep.equal [
+			description: 'SAMSUNG "SSD" PM810 2.5" 7mm 256GB'
+		]


### PR DESCRIPTION
Consider the following description:

	description: "SAMSUNG SSD PM810 2.5" 7mm 256GB"

Because of the double quote in `2.5"`, the YAML parser will complain
with:

	YAMLException: can not read a block mapping entry; a multiline key
	may not be an implicit key at line 2, column 1: