### PR TITLE
OS X: Mark MacBook's internal SDCard reader as system: false

### DIFF
--- a/scripts/darwin.sh
+++ b/scripts/darwin.sh
@@ -33,7 +33,7 @@ for disk in $DISKS; do
 
   if [[ "$device" == "/dev/disk0" ]] || \
      [[ "$removable" == "No" ]] || \
-     [[ "$location" == "Internal" ]] || \
+     [[ ( "$location" == "Internal" ) && ( "$removable" != "Yes" ) ]] || \
      [[ "$mountpoint" == "/" ]]
   then
     echo "system: True"


### PR DESCRIPTION
The issue is that SDCards plugged in the internal card reader have an
`Internal` location, causing the original condition to return true.

Simply removing the `Internal` location check might lead to unexpected
output given there are some drives that don't report a removable flag,
so we have to purely rely on the drive location to determine it.

The following approach returns the correct results:

- If the location is `Internal` and `Removable` is `No`, we print
`system: true`.

- If the location is `Internal` and `Removable` is `Yes`, we print
`system: false`.

- If the location is `Internal` and `Removable` is not defined (which
matches `removable` != `Yes`), we print `system: true`.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>