### PR TITLE
Round Windows drive size keeping one decimal

### DIFF
--- a/scripts/win32.bat
+++ b/scripts/win32.bat
@@ -41,7 +41,7 @@ For Each objDrive In colDiskDrives
         For Each objLogicalDisk In colLogicalDisks
             Wscript.Echo "device: """ & Replace(objDrive.DeviceID, "\", "\\") & """"
             Wscript.Echo "description: """ & objDrive.Caption & """"
-            Wscript.Echo "size: """ & Int(objDrive.Size / 1e+9) & " GB"""
+            Wscript.Echo "size: """ & Round(objDrive.Size / 1e+9, 1) & " GB"""
             Wscript.Echo "mountpoint: """ & objLogicalDisk.DeviceID & """"
             Wscript.Echo "name: """ & objLogicalDisk.DeviceID & """"
 


### PR DESCRIPTION
Previously, we were truncating the decimal part of a drive size. For
consistency with the other platforms, we keep one decimal by using the
`Round` function:

http://www.w3schools.com/asp/func_round.asp

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>