### PR TITLE
Report size in bytes for all operating systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Mac OS X:
 	{
 		device: '/dev/disk0',
 		description: 'GUID_partition_scheme',
-		size: '*750.2 GB'
+		size: 68719476736,
 		mountpoint: '/',
 		name: /dev/disk0,
 		system: true
@@ -46,7 +46,7 @@ Mac OS X:
 	{
 		device: '/dev/disk1',
 		description: 'Apple_HFS Macintosh HD',
-		size: '*748.9 GB',
+		size: 68719476736,
 		name: /dev/disk1,
 		system: true
 	}
@@ -62,7 +62,7 @@ GNU/Linux
 	{
 		device: '/dev/sda',
 		description: 'WDC WD10JPVX-75J',
-		size: '931.5G',
+		size: 68719476736,
 		mountpoint: '/',
 		name: '/dev/sda',
 		system: true
@@ -70,7 +70,7 @@ GNU/Linux
 	{
 		device: '/dev/sdb',
 		description: 'DataTraveler 2.0',
-		size: '7.3G',
+		size: 7823458304,
 		mountpoint: '/media/UNTITLED',
 		name: '/dev/sdb',
 		system: false
@@ -87,7 +87,7 @@ Windows
 	{
 		device: '\\\\.\\PHYSICALDRIVE0',
 		description: 'WDC WD10JPVX-75JC3T0',
-		size: '1000 GB'
+		size: 68719476736,
 		mountpoint: 'C:',
 		name: 'C:',
 		system: true
@@ -95,7 +95,7 @@ Windows
 	{
 		device: '\\\\.\\PHYSICALDRIVE1',
 		description: 'Generic STORAGE DEVICE USB Device',
-		size: '15 GB'
+		size: 7823458304,
 		mountpoint: 'D:',
 		name: 'D:',
 		system: false

--- a/scripts/darwin.sh
+++ b/scripts/darwin.sh
@@ -18,7 +18,7 @@ for disk in $DISKS; do
   mountpoint=`echo "$diskinfo" | get_key "Mount Point"`
   removable=`echo "$diskinfo" | get_key "Removable Media"`
   location=`echo "$diskinfo" | get_key "Device Location"`
-  size=`echo "$diskinfo" | get_key "Total Size" | get_until_paren`
+  size=`echo "$diskinfo" | get_key "Total Size" | perl -n -e'/\((\d+)\sBytes\)/ && print $1'`
 
   # Omit mounted DMG images
   if [ "$description" == "Disk Image" ]; then

--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -27,7 +27,7 @@ for disk in $DISKS; do
 
   device="/dev/$disk"
   description=`lsblk -d $device --output MODEL | ignore_first_line`
-  size=`lsblk -d $device --output SIZE | ignore_first_line | trim`
+  size=`lsblk -b -d $device --output SIZE | ignore_first_line | trim`
   mountpoint=`get_mountpoint $device`
 
   # If we couldn't get the mount points as `/dev/$disk`,

--- a/scripts/win32.bat
+++ b/scripts/win32.bat
@@ -20,7 +20,7 @@ Err.Clear
 For Each objOperatingSystem in colOperatingSystems
     On Error Resume Next
     '' get the OS System Drive if exists
-    OSDrive = objOperatingSystem.Properties_("SystemDrive")   
+    OSDrive = objOperatingSystem.Properties_("SystemDrive")
     If Err.Number <> 0 Then
         OSDrive = False
         Err.Clear
@@ -41,7 +41,7 @@ For Each objDrive In colDiskDrives
         For Each objLogicalDisk In colLogicalDisks
             Wscript.Echo "device: """ & Replace(objDrive.DeviceID, "\", "\\") & """"
             Wscript.Echo "description: """ & objDrive.Caption & """"
-            Wscript.Echo "size: """ & Round(objDrive.Size / 1e+9, 1) & " GB"""
+            Wscript.Echo "size: " & objDrive.Size
             Wscript.Echo "mountpoint: """ & objLogicalDisk.DeviceID & """"
             Wscript.Echo "name: """ & objLogicalDisk.DeviceID & """"
 


### PR DESCRIPTION
Currently, we report back a string containing whatever the operating
system decides is a human-readable size, like "7.8G", however this is
not an ideal format to perform operations on the resulting sizes.

- OS X

The size in bytes is reported by `diskutil info` in parenthesis at the
right of the human-readable size we're currently showing. We use `perl`
and a regular expression to capture the result.

I tried to implemented in `awk` in order to not make use of yet another
tool, however capturing regular expression groups with `awk` proved to
be a pain, or it relied on GNU awk specific features.

- Linux

`lsblk` contains an option `-b` to display the size in bytes rather than
in a human readable format.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>

- Windows

The size property we were getting from the drive object was already in
bytes, but we were manually transforming to a human-readable format
before for consistency reasons.