### PR TITLE
[Windows] Show non-mountable disk drives

### DIFF
--- a/scripts/win32.bat
+++ b/scripts/win32.bat
@@ -29,7 +29,7 @@ Next
 
 For Each objDrive In colDiskDrives
     strDeviceID = Replace(objDrive.DeviceID, "\", "\\")
-    foundLDs = 0
+    containsLogicalDisk = False
     Set colPartitions = objWMIService.ExecQuery _
         ("ASSOCIATORS OF {Win32_DiskDrive.DeviceID=""" & _
             strDeviceID & """} WHERE AssocClass = " & _
@@ -40,7 +40,7 @@ For Each objDrive In colDiskDrives
                 objPartition.DeviceID & """} WHERE AssocClass = " & _
                     "Win32_LogicalDiskToPartition")
         For Each objLogicalDisk In colLogicalDisks
-            foundLDs = foundLDs + 1
+            containsLogicalDisk = True
             Wscript.Echo "device: """ & Replace(objDrive.DeviceID, "\", "\\") & """"
             Wscript.Echo "description: """ & objDrive.Caption & """"
             Wscript.Echo "size: " & objDrive.Size
@@ -56,13 +56,14 @@ For Each objDrive In colDiskDrives
             Wscript.Echo ""
         Next
     Next
-    If foundLDs = 0 Then
+    If containsLogicalDisk = True Then
       Wscript.Echo "device: """ & Replace(objDrive.DeviceID, "\", "\\") & """"
       Wscript.Echo "description: """ & objDrive.Caption & """"
       Wscript.Echo "size: " & objDrive.Size
       Wscript.Echo "mountpoint: Null"
       Wscript.Echo "name: Null"
-      Wscript.Echo "system: False"
+      ' We cannot infer the drive status, so assume it is a system drive
+      Wscript.Echo "system: True"
       Wscript.Echo ""
     End If
 Next

--- a/scripts/win32.bat
+++ b/scripts/win32.bat
@@ -56,7 +56,7 @@ For Each objDrive In colDiskDrives
             Wscript.Echo ""
         Next
     Next
-    If containsLogicalDisk = True Then
+    If containsLogicalDisk = False Then
       Wscript.Echo "device: """ & Replace(objDrive.DeviceID, "\", "\\") & """"
       Wscript.Echo "description: """ & objDrive.Caption & """"
       Wscript.Echo "size: " & objDrive.Size

--- a/scripts/win32.bat
+++ b/scripts/win32.bat
@@ -29,6 +29,7 @@ Next
 
 For Each objDrive In colDiskDrives
     strDeviceID = Replace(objDrive.DeviceID, "\", "\\")
+    foundLDs = 0
     Set colPartitions = objWMIService.ExecQuery _
         ("ASSOCIATORS OF {Win32_DiskDrive.DeviceID=""" & _
             strDeviceID & """} WHERE AssocClass = " & _
@@ -39,6 +40,7 @@ For Each objDrive In colDiskDrives
                 objPartition.DeviceID & """} WHERE AssocClass = " & _
                     "Win32_LogicalDiskToPartition")
         For Each objLogicalDisk In colLogicalDisks
+            foundLDs = foundLDs + 1
             Wscript.Echo "device: """ & Replace(objDrive.DeviceID, "\", "\\") & """"
             Wscript.Echo "description: """ & objDrive.Caption & """"
             Wscript.Echo "size: " & objDrive.Size
@@ -54,5 +56,14 @@ For Each objDrive In colDiskDrives
             Wscript.Echo ""
         Next
     Next
+    If foundLDs = 0 Then
+      Wscript.Echo "device: """ & Replace(objDrive.DeviceID, "\", "\\") & """"
+      Wscript.Echo "description: """ & objDrive.Caption & """"
+      Wscript.Echo "size: " & objDrive.Size
+      Wscript.Echo "mountpoint: Null"
+      Wscript.Echo "name: Null"
+      Wscript.Echo "system: False"
+      Wscript.Echo ""
+    End If
 Next
 </script></job>


### PR DESCRIPTION
This commit returns disk drives that do not contain any mountable partitions under Windows, useful for seeing drives with HFS, ext* or other types of partitions.

(See #72)