### PR TITLE
Set system = true for non-removable Windows drives

### DIFF
--- a/scripts/win32.bat
+++ b/scripts/win32.bat
@@ -47,7 +47,7 @@ For Each objDrive In colDiskDrives
             Wscript.Echo "mountpoint: """ & objLogicalDisk.DeviceID & """"
             Wscript.Echo "name: """ & objLogicalDisk.DeviceID & """"
 
-            If objLogicalDisk.DeviceID = OSDrive Then
+            If (objLogicalDisk.DeviceID = OSDrive) Or Not (InStr(objDrive.MediaType, "Removable") = 1) Then
               Wscript.Echo "system: True"
             Else
               Wscript.Echo "system: False"


### PR DESCRIPTION
See the following documentation page for the `Win32_DiskDrive` WMI
class: https://msdn.microsoft.com/en-us/library/aa394132(v=vs.85).aspx

This class describes a string property called `MediaType` that is useful
to determine the removable state of a drive.

Fixes: https://github.com/resin-io/etcher/issues/421
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>