### PR TITLE
Detect if a drive is write protected

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Mac OS X:
 		size: 68719476736,
 		mountpoint: '/',
 		name: /dev/disk0,
+		protected: false,
 		system: true
 	},
 	{
@@ -48,6 +49,7 @@ Mac OS X:
 		description: 'Apple_HFS Macintosh HD',
 		size: 68719476736,
 		name: /dev/disk1,
+		protected: false,
 		system: true
 	}
 ]
@@ -65,6 +67,7 @@ GNU/Linux
 		size: 68719476736,
 		mountpoint: '/',
 		name: '/dev/sda',
+		protected: false,
 		system: true
 	},
 	{
@@ -73,6 +76,7 @@ GNU/Linux
 		size: 7823458304,
 		mountpoint: '/media/UNTITLED',
 		name: '/dev/sdb',
+		protected: true,
 		system: false
 	}
 ]
@@ -90,6 +94,7 @@ Windows
 		size: 68719476736,
 		mountpoint: 'C:',
 		name: 'C:',
+		protected: false,
 		system: true
 	},
 	{
@@ -98,6 +103,7 @@ Windows
 		size: 7823458304,
 		mountpoint: 'D:',
 		name: 'D:',
+		protected: true,
 		system: false
 	}
 ]

--- a/scripts/darwin.sh
+++ b/scripts/darwin.sh
@@ -17,6 +17,7 @@ for disk in $DISKS; do
   description=`echo "$diskinfo" | get_key "Device / Media Name"`
   mountpoint=`echo "$diskinfo" | get_key "Mount Point"`
   removable=`echo "$diskinfo" | get_key "Removable Media"`
+  protected=`echo "$diskinfo" | get_key "Read-Only Media"`
   location=`echo "$diskinfo" | get_key "Device Location"`
   size=`echo "$diskinfo" | get_key "Total Size" | perl -n -e'/\((\d+)\sBytes\)/ && print $1'`
 
@@ -30,6 +31,12 @@ for disk in $DISKS; do
   echo "size: $size"
   echo "mountpoint: $mountpoint"
   echo "name: $device"
+
+  if [[ "$protected" == "Yes" ]]; then
+    echo "protected: True"
+  else
+    echo "protected: False"
+  fi
 
   if [[ "$device" == "/dev/disk0" ]] || \
      [[ "$removable" == "No" ]] || \

--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -28,6 +28,7 @@ for disk in $DISKS; do
   device="/dev/$disk"
   description=`lsblk -d $device --output MODEL | ignore_first_line`
   size=`lsblk -b -d $device --output SIZE | ignore_first_line | trim`
+  protected=`lsblk -b -d $device --output RO | ignore_first_line | trim`
   mountpoint=`get_mountpoint $device`
 
   # If we couldn't get the mount points as `/dev/$disk`,
@@ -43,6 +44,12 @@ for disk in $DISKS; do
   echo "size: $size"
   echo "mountpoint: $mountpoint"
   echo "name: $device"
+
+  if [[ "$protected" == "1" ]]; then
+    echo "protected: True"
+  else
+    echo "protected: False"
+  fi
 
   eval "`udevadm info --query=property --export --export-prefix=UDEV_ --name=$disk`"
   if [[ "`lsblk -d $device --output RM | ignore_first_line | trim`" == "1" ]] && \

--- a/scripts/win32.bat
+++ b/scripts/win32.bat
@@ -47,6 +47,12 @@ For Each objDrive In colDiskDrives
             Wscript.Echo "mountpoint: """ & objLogicalDisk.DeviceID & """"
             Wscript.Echo "name: """ & objLogicalDisk.DeviceID & """"
 
+            If objLogicalDisk.Access = 1 Then
+              Wscript.Echo "protected: True"
+            Else 
+              Wscript.Echo "protected: False"
+            End If
+
             If (objLogicalDisk.DeviceID = OSDrive) Or Not (InStr(objDrive.MediaType, "Removable") = 1) Then
               Wscript.Echo "system: True"
             Else


### PR DESCRIPTION
This might be the case of an SDCard with a lock.
We use the following approaches to determine this:

OS X
----

Check the `Read-Only Media` from `diskutil info`.

GNU/Linux
---------

Check the `RO` (read-only) flag from `lsblk`.

Windows
-------

Check the `Access` property from the `Win32_LogicalDisk` WMI class.

See: https://github.com/resin-io/etcher/issues/458
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>