### PR TITLE
Get mountpoints using `df` in GNU/Linux

### DIFF
--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -13,7 +13,7 @@ function get_uuids {
 }
 
 function get_mountpoint {
-  grep "^$1" /proc/mounts | cut -d ' ' -f 2 | tr '\n' ','
+  df --output=source,target | grep "^$1" | awk -F ' ' '{print $2}' | tr '\n' ','
 }
 
 DISKS="`lsblk -d --output NAME | ignore_first_line`"


### PR DESCRIPTION
`df` proved to be the most reliable way to get the correct mountpoint
for a drive rather than grepping `/proc/mounts` and having to deal with
drives listed by label, uuid, etc.

Fixes: https://github.com/resin-io-modules/drivelist/issues/74
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>