### PR TITLE
Fix drive without filesystem always being considered non-removable

### DIFF
--- a/scripts/win32.bat
+++ b/scripts/win32.bat
@@ -68,8 +68,13 @@ For Each objDrive In colDiskDrives
       Wscript.Echo "size: " & objDrive.Size
       Wscript.Echo "mountpoint: Null"
       Wscript.Echo "name: Null"
-      ' We cannot infer the drive status, so assume it is a system drive
-      Wscript.Echo "system: True"
+
+      If InStr(objDrive.MediaType, "Removable") = 1 Then
+        Wscript.Echo "system: False"
+      Else
+        Wscript.Echo "system: True"
+      End If
+
       Wscript.Echo ""
     End If
 Next


### PR DESCRIPTION
Before knowing about the `MediaType` property from the `Win32_DiskDrive`
structure, we though we had no realiable way of doing this

See: https://github.com/resin-io/etcher/issues/571
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>