### PR TITLE
Handle multiline mountpoints in GNU/Linux

### DIFF
--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -13,7 +13,7 @@ function get_uuids {
 }
 
 function get_mountpoint {
-  df --output=source,target | grep "^$1" | awk -F ' ' '{print $2}' | tr '\n' ','
+  df --output=source,target | grep "^$1" | awk '!($1="")&&gsub(/^ /,"")' | tr '\n' ','
 }
 
 DISKS="`lsblk -d --output NAME | ignore_first_line`"


### PR DESCRIPTION
The current `awk` command, `awk -F ' ' '{print $2}'`, will not return
the whole second column if this contains spaces.

See: https://github.com/resin-io-modules/drivelist/issues/69#issuecomment-235168735
See: http://stackoverflow.com/questions/14327442/treat-second-column-with-spaces-as-one-column-with-awk
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>