### PR TITLE
Qmarks can occur in block device descriptions

### DIFF
--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -26,7 +26,8 @@ for disk in $DISKS; do
   fi
 
   device="/dev/$disk"
-  description=`lsblk -d $device --output MODEL | ignore_first_line`
+  description="$(lsblk -d $device --output MODEL | ignore_first_line | trim)"
+  description="\"${description//"/\\"}\""
   size=`lsblk -b -d $device --output SIZE | ignore_first_line | trim`
   protected=`lsblk -b -d $device --output RO | ignore_first_line | trim`
   mountpoint=`get_mountpoint $device`


### PR DESCRIPTION
This breaks the YAML when it occurs.  Added escaping to descriptions.