### PR TITLE
Detect a drive as removable if "Removable Media" equals "Removable"

### DIFF
--- a/scripts/darwin.sh
+++ b/scripts/darwin.sh
@@ -40,7 +40,7 @@ for disk in $DISKS; do
 
   if [[ "$device" == "/dev/disk0" ]] || \
      [[ "$removable" == "No" ]] || \
-     [[ ( "$location" == "Internal" ) && ( "$removable" != "Yes" ) ]] || \
+     [[ ( "$location" == "Internal" ) && ( "$removable" != "Yes" ) && ( "$removable" != "Removable" ) ]] || \
      [[ "$mountpoint" == "/" ]]
   then
     echo "system: True"


### PR DESCRIPTION
In macOS Sierra, the "Removable Media" property no longer equals to
"Yes", but "Removable".

This PR accounts for this change while still maintaining backwards
compatibility.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>