### PR TITLE
Attempt to display the volume name as description in OS X

### DIFF
--- a/scripts/darwin.sh
+++ b/scripts/darwin.sh
@@ -15,6 +15,7 @@ for disk in $DISKS; do
 
   device=`echo "$diskinfo" | get_key "Device Node"`
   description=`echo "$diskinfo" | get_key "Device / Media Name"`
+  volume_name=`echo "$diskinfo" | get_key "Volume Name"`
   mountpoint=`echo "$diskinfo" | get_key "Mount Point"`
   removable=`echo "$diskinfo" | get_key "Removable Media"`
   protected=`echo "$diskinfo" | get_key "Read-Only Media"`
@@ -27,7 +28,15 @@ for disk in $DISKS; do
   fi
 
   echo "device: $device"
-  echo "description: $description"
+
+  # Attempt to use the volume name if applicable,
+  # since it provides a much more readable name.
+  if [[ $volume_name =~ .*Not\ applicable.* ]]; then
+    echo "description: $description"
+  else
+    echo "description: $volume_name"
+  fi
+
   echo "size: $size"
   echo "mountpoint: $mountpoint"
   echo "name: $device"


### PR DESCRIPTION
The `Volume Name` key contains a much more human friendly description
for the drive. This PR attempts to use is over `Device / Media Name`
unless its not applicable. For example

```
Volume Name:              Not applicable (no file system)
```

Fixes: https://github.com/resin-io-modules/drivelist/issues/88
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>