### PR TITLE
Expose a "raw" key for all devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Examples (the output will vary depending on your machine):
 var drivelist = require('drivelist');
 
 drivelist.list(function(error, disks) {
-		if (error) throw error;
-		console.log(disks);
+    if (error) throw error;
+    console.log(disks);
 });
 
 ```
@@ -35,23 +35,25 @@ Mac OS X:
 
 ```sh
 [
-	{
-		device: '/dev/disk0',
-		description: 'GUID_partition_scheme',
-		size: 68719476736,
-		mountpoint: '/',
-		name: /dev/disk0,
-		protected: false,
-		system: true
-	},
-	{
-		device: '/dev/disk1',
-		description: 'Apple_HFS Macintosh HD',
-		size: 68719476736,
-		name: /dev/disk1,
-		protected: false,
-		system: true
-	}
+  {
+    device: '/dev/disk0',
+    description: 'GUID_partition_scheme',
+    size: 68719476736,
+    mountpoint: '/',
+    name: /dev/disk0,
+    raw: /dev/rdisk0,
+    protected: false,
+    system: true
+  },
+  {
+    device: '/dev/disk1',
+    description: 'Apple_HFS Macintosh HD',
+    size: 68719476736,
+    name: /dev/disk1,
+    raw: /dev/rdisk0,
+    protected: false,
+    system: true
+  }
 ]
 ```
 
@@ -61,24 +63,26 @@ GNU/Linux
 
 ```sh
 [
-	{
-		device: '/dev/sda',
-		description: 'WDC WD10JPVX-75J',
-		size: 68719476736,
-		mountpoint: '/',
-		name: '/dev/sda',
-		protected: false,
-		system: true
-	},
-	{
-		device: '/dev/sdb',
-		description: 'DataTraveler 2.0',
-		size: 7823458304,
-		mountpoint: '/media/UNTITLED',
-		name: '/dev/sdb',
-		protected: true,
-		system: false
-	}
+  {
+    device: '/dev/sda',
+    description: 'WDC WD10JPVX-75J',
+    size: 68719476736,
+    mountpoint: '/',
+    name: '/dev/sda',
+    raw: '/dev/sda',
+    protected: false,
+    system: true
+  },
+  {
+    device: '/dev/sdb',
+    description: 'DataTraveler 2.0',
+    size: 7823458304,
+    mountpoint: '/media/UNTITLED',
+    name: '/dev/sdb',
+    raw: '/dev/sdb',
+    protected: true,
+    system: false
+  }
 ]
 ```
 
@@ -88,24 +92,26 @@ Windows
 
 ```sh
 [
-	{
-		device: '\\\\.\\PHYSICALDRIVE0',
-		description: 'WDC WD10JPVX-75JC3T0',
-		size: 68719476736,
-		mountpoint: 'C:',
-		name: 'C:',
-		protected: false,
-		system: true
-	},
-	{
-		device: '\\\\.\\PHYSICALDRIVE1',
-		description: 'Generic STORAGE DEVICE USB Device',
-		size: 7823458304,
-		mountpoint: 'D:',
-		name: 'D:',
-		protected: true,
-		system: false
-	}
+  {
+    device: '\\\\.\\PHYSICALDRIVE0',
+    description: 'WDC WD10JPVX-75JC3T0',
+    size: 68719476736,
+    mountpoint: 'C:',
+    name: 'C:',
+    raw: '\\\\.\\PHYSICALDRIVE0',
+    protected: false,
+    system: true
+  },
+  {
+    device: '\\\\.\\PHYSICALDRIVE1',
+    description: 'Generic STORAGE DEVICE USB Device',
+    size: 7823458304,
+    mountpoint: 'D:',
+    name: 'D:',
+    raw: '\\\\.\\PHYSICALDRIVE1',
+    protected: true,
+    system: false
+  }
 ]
 ```
 

--- a/scripts/darwin.sh
+++ b/scripts/darwin.sh
@@ -14,6 +14,10 @@ for disk in $DISKS; do
   diskinfo="`diskutil info $disk`"
 
   device=`echo "$diskinfo" | get_key "Device Node"`
+
+  # See http://superuser.com/q/631592
+  raw_device=`echo "$device" | sed "s/disk/rdisk/g"`
+
   description=`echo "$diskinfo" | get_key "Device / Media Name"`
   mountpoint=`echo "$diskinfo" | get_key "Mount Point"`
   removable=`echo "$diskinfo" | get_key "Removable Media"`
@@ -31,6 +35,7 @@ for disk in $DISKS; do
   echo "size: $size"
   echo "mountpoint: $mountpoint"
   echo "name: $device"
+  echo "raw: $raw_device"
 
   if [[ "$protected" == "Yes" ]]; then
     echo "protected: True"

--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -45,6 +45,7 @@ for disk in $DISKS; do
   echo "size: $size"
   echo "mountpoint: $mountpoint"
   echo "name: $device"
+  echo "raw: $device"
 
   if [[ "$protected" == "1" ]]; then
     echo "protected: True"

--- a/scripts/win32.bat
+++ b/scripts/win32.bat
@@ -46,10 +46,11 @@ For Each objDrive In colDiskDrives
             Wscript.Echo "size: " & objDrive.Size
             Wscript.Echo "mountpoint: """ & objLogicalDisk.DeviceID & """"
             Wscript.Echo "name: """ & objLogicalDisk.DeviceID & """"
+            Wscript.Echo "raw: """ & Replace(objDrive.DeviceID, "\", "\\") & """"
 
             If objLogicalDisk.Access = 1 Then
               Wscript.Echo "protected: True"
-            Else 
+            Else
               Wscript.Echo "protected: False"
             End If
 
@@ -68,6 +69,7 @@ For Each objDrive In colDiskDrives
       Wscript.Echo "size: " & objDrive.Size
       Wscript.Echo "mountpoint: Null"
       Wscript.Echo "name: Null"
+      Wscript.Echo "raw: """ & Replace(objDrive.DeviceID, "\", "\\") & """"
 
       If InStr(objDrive.MediaType, "Removable") = 1 Then
         Wscript.Echo "system: False"


### PR DESCRIPTION
This property contains the path to the "raw" device. This is mainly
relevant in OS X, where a raw device is denoted as `/dev/rdiskN`.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>