### PR TITLE
Fix null device when unplugging a drive while detecting drives

### DIFF
--- a/build/parse.js
+++ b/build/parse.js
@@ -59,7 +59,7 @@ module.exports = function(input) {
     if (_.isString(result)) {
       return _.object([result], [null]);
     }
-    if (result == null) {
+    if ((result == null) || (result.device == null)) {
       return;
     }
     return _.mapValues(result, function(value, key) {

--- a/lib/parse.coffee
+++ b/lib/parse.coffee
@@ -55,7 +55,7 @@ module.exports = (input) ->
 		result = yaml.safeLoad(device)
 		if _.isString(result)
 			return _.object([ result ], [ null ])
-		return if not result?
+		return if not result? or not result.device?
 
 		return _.mapValues result, (value, key) ->
 			return value if not _.isString(value)

--- a/tests/parse.spec.coffee
+++ b/tests/parse.spec.coffee
@@ -50,6 +50,25 @@ describe 'Parse:', ->
 			mountpoint: '/Volumes/Elementary'
 		]
 
+	it 'should omit blank devices', ->
+		m.chai.expect parse '''
+			device: /dev/disk1
+			description: Macintosh HD
+			size: 249.8 GB
+			mountpoint: /
+
+			device:
+			description:
+			size:
+			mountpoint:
+		'''
+		.to.deep.equal [
+			device: '/dev/disk1'
+			description: 'Macintosh HD'
+			size: '249.8 GB'
+			mountpoint: '/'
+		]
+
 	it 'should ignore new lines after the output', ->
 		m.chai.expect parse '''
 			device: /dev/disk1
@@ -79,47 +98,59 @@ describe 'Parse:', ->
 
 	it 'should discard trailing commas', ->
 		m.chai.expect parse '''
+			device: /dev/disk1
 			hello: foo,bar,baz,
 		'''
 		.to.deep.equal [
+			device: '/dev/disk1'
 			hello: 'foo,bar,baz'
 		]
 
 	it 'should parse a truthy boolean', ->
 		m.chai.expect parse '''
+			device: /dev/disk1
 			hello: True
 		'''
 		.to.deep.equal [
+			device: '/dev/disk1'
 			hello: true
 		]
 
 	it 'should parse a falsy boolean', ->
 		m.chai.expect parse '''
+			device: /dev/disk1
 			hello: False
 		'''
 		.to.deep.equal [
+			device: '/dev/disk1'
 			hello: false
 		]
 
 	it 'should parse multiple devices that are heterogeneous', ->
 		m.chai.expect parse '''
+			device: /dev/disk1
 			hello: world
 			foo: bar
 
+			device: /dev/disk2
 			hey: there
 		'''
 		.to.deep.equal [
+			device: '/dev/disk1'
 			hello: 'world'
 			foo: 'bar'
 		,
+			device: '/dev/disk2'
 			hey: 'there'
 		]
 
 	it 'should set null for values without keys', ->
 		m.chai.expect parse '''
+			device: /dev/disk1
 			hello:
 		'''
 		.to.deep.equal [
+			device: '/dev/disk1'
 			hello: null
 		]
 
@@ -141,16 +172,20 @@ describe 'Parse:', ->
 
 	it 'should handle a double quote inside a value', ->
 		m.chai.expect parse '''
+			device: /dev/disk1
 			description: "SAMSUNG SSD PM810 2.5" 7mm 256GB"
 		'''
 		.to.deep.equal [
+			device: '/dev/disk1'
 			description: 'SAMSUNG SSD PM810 2.5" 7mm 256GB'
 		]
 
 	it 'should handle multiple double quotes inside a value', ->
 		m.chai.expect parse '''
+			device: /dev/disk1
 			description: "SAMSUNG "SSD" PM810 2.5" 7mm 256GB"
 		'''
 		.to.deep.equal [
+			device: '/dev/disk1'
 			description: 'SAMSUNG "SSD" PM810 2.5" 7mm 256GB'
 		]


### PR DESCRIPTION
If we unplug the drive right at the same time when the script gets run
(quite tricky to reproduce), the resulting device object will have all
keys unset. For example:

```
device:
description:
size:
mountpoint:
name:
protected: False
system: False
```

To fix this, we omit drives that don't have a defined `.device`
property.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>