### PR TITLE
Refer to `blkid` as `/sbin/blkid` in GNU/Linux

### DIFF
--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -9,7 +9,7 @@ function trim {
 }
 
 function get_uuids {
-  blkid -s UUID -o value $1*
+  /sbin/blkid -s UUID -o value $1*
 }
 
 function get_mountpoint {


### PR DESCRIPTION
Some GNU/Linux distributions don't have `/sbin` in the `PATH` by default
(like Debian), causing an `blkid: command not found` error when
attempting to scan the drives.

After some research and testing, `blkid` is virtually always present in
`/sbin`, its standard location, so we should be fine by referencing to
it directly.

See: https://github.com/resin-io/etcher/issues/640
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>