### PR TITLE
Add 'mountpoints' property on Mac

### DIFF
--- a/scripts/darwin.sh
+++ b/scripts/darwin.sh
@@ -26,7 +26,7 @@ for disk in $DISKS; do
   location=`echo "$diskinfo" | get_key "Device Location"`
   size=`echo "$diskinfo" | sed 's/Disk Size/Total Size/g' | get_key "Total Size" | perl -n -e'/\((\d+)\sBytes\)/ && print $1'`
 
-  mountpoint=`echo "$mount_output" | perl -n -e'm{'"^${disk}(s[0-9]+)? on (.*) \(.*\)$"'} && print ",$2"'`
+  mountpoint=`echo "$mount_output" | perl -n -e'm{^'"${disk}"'(s[0-9]+)? on (.*) \(.*\)$} && print ",$2"'`
   # trim leading ,
   mountpoint=${mountpoint#,}
 

--- a/scripts/darwin.sh
+++ b/scripts/darwin.sh
@@ -8,10 +8,6 @@ function get_until_paren {
   awk 'match($0, "\\(|$"){ print substr($0, 0, RSTART - 1) }'
 }
 
-function get_device_identifiers {
-  awk 'match($0, /disk[0-9]+(s[0-9]+)?$/, arr){ print "/dev/" arr[0] }'
-}
-
 DISKS="`diskutil list | grep '^\/' | get_until_paren`"
 mount_output="`mount`"
 


### PR DESCRIPTION
As per #75, this adds a `mountpoints` property, which is an array of the mount points of the partitions of the devices connected.

Example output:

```
$ node -e "require('./build/drivelist').list(function(err, list) { console.log(list) })"                 master!
[ { device: '/dev/disk0',
    description: 'APPLE SSD SM0512F',
    size: 500277790720,
    mountpoint: null,
    name: '/dev/disk0',
    raw: '/dev/rdisk0',
    protected: false,
    system: true,
    mountpoints: [ '/', '/Volumes/BOOTCAMP' ] },
  { device: '/dev/disk2',
    description: 'SD Card Reader',
    size: 7969177600,
    mountpoint: null,
    name: '/dev/disk2',
    raw: '/dev/rdisk2',
    protected: false,
    system: false,
    mountpoints: [ '/Volumes/boot', '/Volumes/Untitled' ] },
  { device: '/dev/disk4',
    description: 'External USB 3.0',
    size: 1000204883968,
    mountpoint: null,
    name: '/dev/disk4',
    raw: '/dev/rdisk4',
    protected: false,
    system: true,
    mountpoints: [] },
  { device: '/dev/disk5',
    description: 'Joe backup HD',
    size: 999489667072,
    mountpoint: '/Volumes/Joe backup HD 1',
    name: '/dev/disk5',
    raw: '/dev/rdisk5',
    protected: false,
    system: true,
    mountpoints: [ '/Volumes/Joe backup HD 1' ] } ]
```

Worth noting that this does increase the execution time to 5 seconds on my machine, compared to 2 seconds before this patch. Not a concern for my applications though.