### PR TITLE
Ensure System32 is in the PATH before calling `cscript.exe`

### DIFF
--- a/scripts/win32.bat
+++ b/scripts/win32.bat
@@ -1,5 +1,10 @@
 <!-- : Begin batch script
 @echo off
+
+:: Ensure System32 is in the PATH, to avoid weird
+:: 'cscript' is not recognized as an internal or external command"" errors.
+set PATH=%PATH%;%SYSTEMROOT%\System32
+
 cscript //nologo "%~f0?.wsf"
 exit /b
 


### PR DESCRIPTION
We've seem some users getting the following weird error:

> 'cscript' is not recognized as an internal or external command

After some investigation, the only possible cause of this is that the
PATH may have been altered in the user setup somehow.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>