### PR TITLE
Remove `name` property from resulting drives

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Mac OS X:
     description: 'GUID_partition_scheme',
     size: 68719476736,
     mountpoint: '/',
-    name: /dev/disk0,
     raw: /dev/rdisk0,
     protected: false,
     system: true
@@ -49,7 +48,6 @@ Mac OS X:
     device: '/dev/disk1',
     description: 'Apple_HFS Macintosh HD',
     size: 68719476736,
-    name: /dev/disk1,
     raw: /dev/rdisk0,
     protected: false,
     system: true
@@ -68,7 +66,6 @@ GNU/Linux
     description: 'WDC WD10JPVX-75J',
     size: 68719476736,
     mountpoint: '/',
-    name: '/dev/sda',
     raw: '/dev/sda',
     protected: false,
     system: true
@@ -78,7 +75,6 @@ GNU/Linux
     description: 'DataTraveler 2.0',
     size: 7823458304,
     mountpoint: '/media/UNTITLED',
-    name: '/dev/sdb',
     raw: '/dev/sdb',
     protected: true,
     system: false
@@ -97,7 +93,6 @@ Windows
     description: 'WDC WD10JPVX-75JC3T0',
     size: 68719476736,
     mountpoint: 'C:',
-    name: 'C:',
     raw: '\\\\.\\PHYSICALDRIVE0',
     protected: false,
     system: true
@@ -107,7 +102,6 @@ Windows
     description: 'Generic STORAGE DEVICE USB Device',
     size: 7823458304,
     mountpoint: 'D:',
-    name: 'D:',
     raw: '\\\\.\\PHYSICALDRIVE1',
     protected: true,
     system: false

--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -40,7 +40,6 @@ Mac OS X:
     description: 'GUID_partition_scheme',
     size: 68719476736,
     mountpoint: '/',
-    name: /dev/disk0,
     raw: /dev/rdisk0,
     protected: false,
     system: true
@@ -49,7 +48,6 @@ Mac OS X:
     device: '/dev/disk1',
     description: 'Apple_HFS Macintosh HD',
     size: 68719476736,
-    name: /dev/disk1,
     raw: /dev/rdisk0,
     protected: false,
     system: true
@@ -68,7 +66,6 @@ GNU/Linux
     description: 'WDC WD10JPVX-75J',
     size: 68719476736,
     mountpoint: '/',
-    name: '/dev/sda',
     raw: '/dev/sda',
     protected: false,
     system: true
@@ -78,7 +75,6 @@ GNU/Linux
     description: 'DataTraveler 2.0',
     size: 7823458304,
     mountpoint: '/media/UNTITLED',
-    name: '/dev/sdb',
     raw: '/dev/sdb',
     protected: true,
     system: false
@@ -97,7 +93,6 @@ Windows
     description: 'WDC WD10JPVX-75JC3T0',
     size: 68719476736,
     mountpoint: 'C:',
-    name: 'C:',
     raw: '\\\\.\\PHYSICALDRIVE0',
     protected: false,
     system: true
@@ -107,7 +102,6 @@ Windows
     description: 'Generic STORAGE DEVICE USB Device',
     size: 7823458304,
     mountpoint: 'D:',
-    name: 'D:',
     raw: '\\\\.\\PHYSICALDRIVE1',
     protected: true,
     system: false

--- a/scripts/darwin.sh
+++ b/scripts/darwin.sh
@@ -47,7 +47,6 @@ for disk in $DISKS; do
 
   echo "size: $size"
   echo "mountpoint: $mountpoint"
-  echo "name: $device"
   echo "raw: $raw_device"
 
   if [[ "$protected" == "Yes" ]]; then

--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -44,7 +44,6 @@ for disk in $DISKS; do
   echo "description: $description"
   echo "size: $size"
   echo "mountpoint: $mountpoint"
-  echo "name: $device"
   echo "raw: $device"
 
   if [[ "$protected" == "1" ]]; then

--- a/scripts/win32.bat
+++ b/scripts/win32.bat
@@ -100,7 +100,6 @@ For Each TopLevelDrive In GetTopLevelDrives()
 	Wscript.Echo "description: """ & TopLevelDrive.Item("Description") & """"
 	Wscript.Echo "size: " & TopLevelDrive.Item("Size")
 	Wscript.Echo "raw: """ & TopLevelDrive.Item("Device") & """"
-	Wscript.Echo "name: """ & TopLevelDrive.Item("Device") & """"
 	Wscript.Echo "system: " & BooleanToString(Not TopLevelDrive.Item("IsRemovable"))
 	Wscript.Echo "protected: " & BooleanToString(TopLevelDrive.Item("IsProtected"))
 


### PR DESCRIPTION
The `name` property currently always equals `device`.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>