### PR TITLE
Syntax typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Mac OS X:
     description: 'GUID_partition_scheme',
     size: 68719476736,
     mountpoint: '/',
-    raw: /dev/rdisk0,
+    raw: '/dev/rdisk0',
     protected: false,
     system: true
   },
@@ -50,7 +50,7 @@ Mac OS X:
     device: '/dev/disk1',
     description: 'Apple_HFS Macintosh HD',
     size: 68719476736,
-    raw: /dev/rdisk0,
+    raw: '/dev/rdisk0',
     protected: false,
     system: true
   }


### PR DESCRIPTION
Quote the Mac OS X example raw values.

I don't have a Mac with which to test, but I'm _assuming_ this update is correct, based on the examples shown for the other OSes?