### PR TITLE
Add OS X README example syntax fix to doc/README.hbs

### DIFF
--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -42,7 +42,7 @@ Mac OS X:
     description: 'GUID_partition_scheme',
     size: 68719476736,
     mountpoint: '/',
-    raw: /dev/rdisk0,
+    raw: '/dev/rdisk0',
     protected: false,
     system: true
   },
@@ -50,7 +50,7 @@ Mac OS X:
     device: '/dev/disk1',
     description: 'Apple_HFS Macintosh HD',
     size: 68719476736,
-    raw: /dev/rdisk0,
+    raw: '/dev/rdisk0',
     protected: false,
     system: true
   }


### PR DESCRIPTION
See: https://github.com/resin-io-modules/drivelist/pull/105
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>