### PR TITLE
Surround Windows mountpoints by double quotes

### DIFF
--- a/scripts/win32.bat
+++ b/scripts/win32.bat
@@ -108,7 +108,7 @@ For Each TopLevelDrive In GetTopLevelDrives()
 	Else
 		Wscript.Echo "mountpoints:"
 		For Each Mountpoint In TopLevelDrive.Item("Mountpoints")
-			Wscript.Echo "  - path: " & Mountpoint
+			Wscript.Echo "  - path: """ & Mountpoint & """"
 		Next
 	End If
 


### PR DESCRIPTION
Windows mount points usually contain colons (e.g: `C:`), but the colon
has a special meaning in YAML, which causes the following exception:

```
Uncaught Exception:
YAMLException: bad indentation of a sequence entry at line 8, column 12:
- path: C:
``````

Fixes: https://github.com/resin-io-modules/drivelist/issues/115
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>