### PR TITLE
Fix mountpoint list spacing

### DIFF
--- a/scripts/win32.bat
+++ b/scripts/win32.bat
@@ -128,7 +128,7 @@ For Each TopLevelDrive In GetTopLevelDrives().GetArray()
 	Else
 		Wscript.Echo "mountpoints:"
 		For Each Mountpoint In TopLevelDrive.Item("Mountpoints").GetArray()
-			Wscript.Echo "	- path: """ & Mountpoint & """"
+			Wscript.Echo "  - path: """ & Mountpoint & """"
 		Next
 	End If
 


### PR DESCRIPTION
The two spaces preceding the hyphen have been accidentally replaced by a
tab in https://github.com/resin-io-modules/drivelist/pull/120, causing
the YAML parser to get confused and not output any mountpoints.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>