### PR TITLE
Replace periods with underscores in udevadm variable name output

### DIFF
--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -68,7 +68,13 @@ for disk in $DISKS; do
     echo "protected: False"
   fi
 
-  eval "`udevadm info --query=property --export --export-prefix=UDEV_ --name=$disk`"
+  eval "`udevadm info \
+    --query=property \
+    --export \
+    --export-prefix=UDEV_ \
+    --name=$disk \
+    | awk -F= '{gsub("\\\\.","_",$1); print $1 "=" $2}'`"
+
   if [[ "$removable" == "1" ]] && \
      [[ "$UDEV_ID_DRIVE_FLASH_SD" == "1" ]] || \
      [[ "$UDEV_ID_DRIVE_MEDIA_FLASH_SD" == "1" ]] || \


### PR DESCRIPTION
We use the `udevadm` command to output a list of environment variable
declarations that we later evaluate into the current script to access
drive related information.

This is an example output of `udevadm`:

```
UDEV_ID_TYPE='disk'
UDEV_ID_USB_DRIVER='usb-storage'
UDEV_ID_USB_INTERFACES=':080650:'
UDEV_ID_USB_INTERFACE_NUM='00'
```

The problem is that in some cases, the variable name printed by
`udevadm` might contain a period, which is of course invalid. For
example:

```
UDEV_net.ifnames='0'
```

As a way to prevent bash errors, we now replace every period on the
variable name with an underscore, so the following variable will be
renamed to `UDEV_net_ifnames`.

Thanks to @wrboyce for the `awk` magic!

Fixes: https://github.com/resin-io-modules/drivelist/issues/122
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>