### PR TITLE
Consider multiple "Device Location" keys in Mac Minis

### DIFF
--- a/scripts/darwin.sh
+++ b/scripts/darwin.sh
@@ -1,7 +1,17 @@
 #!/bin/sh
 
 function get_key {
-  grep "$1" | awk -F "  +" '{ print $3 }'
+  awk -F "  +" "
+    /${1/\//\/}/ {
+      if (values) {
+        values = values \" \" \$3
+      } else {
+        values = \$3
+      }
+    }
+
+    END { print values }
+  "
 }
 
 function get_until_paren {
@@ -64,7 +74,7 @@ for disk in $DISKS; do
 
   if [[ "$device" == "/dev/disk0" ]] || \
      [[ "$removable" == "No" ]] || \
-     [[ ( "$location" == "Internal" ) && ( "$removable" != "Yes" ) && ( "$removable" != "Removable" ) ]] || \
+     [[ ( "$location" =~ "Internal" ) && ( "$removable" != "Yes" ) && ( "$removable" != "Removable" ) ]] || \
      echo "$mountpoints" | grep "^/$"
   then
     echo "system: True"


### PR DESCRIPTION
Mac Minis might report multiple "Device Location" keys in the output of
`diskutil info /dev/diskN`, for example:

```
   Device Identifier:        disk1
   Device Node:              /dev/disk1
   Whole:                    Yes
   Part of Whole:            disk1
   Device / Media Name:      ST2000LM003 HN-M201RAD

   Volume Name:              Not applicable (no file system)
   Mounted:                  Not applicable (no file system)
   File System:              None

   Content (IOContent):      GUID_partition_scheme
   OS Can Be Installed:      No
   Media Type:               Generic
   Protocol:                 SATA
   SMART Status:             Verified

   Disk Size:                2.0 TB (2000398934016 Bytes) (exactly 3907029168 512-Byte-Units)
   Device Block Size:        512 Bytes

   Read-Only Media:          No
   Read-Only Volume:         Not applicable (no file system)

   Device Location:          Internal
   Removable Media:          Fixed

   Solid State:              No
   Virtual:                  No
   OS 9 Drivers:             No
   Low Level Format:         Not supported
   Device Location:          "Lower"
```

Notice that the above example contains:

```
   Device Location:          Internal
```

And:

```
   Device Location:          "Lower"
```

Which then causes equality checks against the value to fail (since the
final value retrieved by `get_key` contains multiple lines).

As a solution, we modify `get_key` to accumulate all found values into a
space separated string, and we then use `=~` to check against it.

See: https://github.com/resin-io/etcher/issues/983
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>