### PR TITLE
Fix VBScript error where a drive has duplicate drive letters

### DIFF
--- a/scripts/win32.bat
+++ b/scripts/win32.bat
@@ -29,6 +29,17 @@ Class List
 	Public Function Count
 		Count = UBound(Dictionary.Keys()) + 1
 	End Function
+
+	' Only works for simple types (e.g: not objects)
+	Public Function Has(element)
+		Result = False
+		For Each Key In Dictionary.Keys()
+			If Key = Element Then
+				Result = True
+			End If
+		Next
+		Has = Result
+	End Function
 End Class
 
 Set WMIService = GetObject("winmgmts:\\.\root\cimv2")
@@ -96,7 +107,9 @@ Function GetTopLevelDrives()
 		Set LogicalDisks = GetLogicalDisks(DeviceID)
 
 		For Each LogicalDisk In LogicalDisks.GetArray()
-			Mountpoints.Add(LogicalDisk.Item("Device"))
+			If Not Mountpoints.Has(LogicalDisk.Item("Device")) Then
+				Mountpoints.Add(LogicalDisk.Item("Device"))
+			End If
 
 			If LogicalDisk.Item("IsProtected") Then
 				IsProtected = True


### PR DESCRIPTION
We've encountered a case where a different partitions of a single drive
were reported to have the exact same drive letter. This is obviously
weird unexpected behaviour in the first case, which seems to have
accidentally caused while manually fiddling with drive letters (maybe a
Windows bug?).

In any case, the symptom of the issue was the following error:

```
Microsoft VBScript runtime error: This key is already associated with an
element of this collection
```

We have our own `List` data structure based on `Scripting.Dictionary`,
which will complain with the error above if we try to set a key that
already exists.

Checking if an element already exists in the list is sadly not an easy
venture (mainly when dealing with non-scalar types). As a solution,
we've implemented a `Has()` method that only works with scalar types
(for now), and use that to decide whether we add a drive letter to the
list of mount-points or not.

See: https://github.com/resin-io/etcher/issues/1004#event-920192906
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>