### PR TITLE
Interpret "Fixed" drives as system drives

### DIFF
--- a/scripts/darwin.sh
+++ b/scripts/darwin.sh
@@ -63,7 +63,7 @@ for disk in $DISKS; do
   fi
 
   if [[ "$device" == "/dev/disk0" ]] || \
-     [[ "$removable" == "No" ]] || \
+     [[ ( "$removable" == "No" ) || ("$removable" == "Fixed") ]] || \
      [[ ( "$location" =~ "Internal" ) && ( "$removable" != "Yes" ) && ( "$removable" != "Removable" ) ]] || \
      echo "$mountpoints" | grep "^/$"
   then


### PR DESCRIPTION
An USB SSD HD (Samsung T3) has the following `diskutil` properties on
macOS Sierra:

```sh
   Device Identifier:        disk3
   Device Node:              /dev/disk3
   Whole:                    Yes
   Part of Whole:            disk3
   Device / Media Name:      Portable SSD T3

   Volume Name:              Not applicable (no file system)
   Mounted:                  Not applicable (no file system)
   File System:              None

   Content (IOContent):      FDisk_partition_scheme
   OS Can Be Installed:      No
   Media Type:               Generic
   Protocol:                 USB
   SMART Status:             Not Supported

   Disk Size:                500.1 GB (500107862016 Bytes) (exactly 976773168512-Byte-Units)
   Device Block Size:        512 Bytes

   Read-Only Media:          No
   Read-Only Volume:         Not applicable (no file system)

   Device Location:          External
   Removable Media:          Fixed

   Virtual:                  No
   OS 9 Drivers:             No
   Low Level Format:         Not supported
```

Because we only check for `Removable Media == No`, this drive will be
detected as something we can freely write to.

The solution is to also check for `Removable Media == Fixed`.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>