### PR TITLE
Double quote PATH declaration in win32.bat

### DIFF
--- a/scripts/win32.bat
+++ b/scripts/win32.bat
@@ -3,7 +3,11 @@
 
 :: Ensure System32 is in the PATH, to avoid weird
 :: 'cscript' is not recognized as an internal or external command"" errors.
-set PATH=%PATH%;%SYSTEMROOT%\System32
+
+:: We double quote the whole thing to prevent file
+:: name spaces from messing up the PATH variable.
+:: See https://github.com/cmderdev/cmder/issues/443#issuecomment-150202124
+set "PATH=%PATH%;%SYSTEMROOT%\System32"
 
 cscript //nologo "%~f0?.wsf"
 exit /b


### PR DESCRIPTION
Failing to do so can introduce problems when some of the directories in
include spaces in their paths, eventually manifesting themselves as
weird "is not recognized as an internal or external command,
operable program or batch file" errors.

See: https://github.com/resin-io/etcher/issues/1025
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>