### PR TITLE
Improve darwin.sh based on shellcheck tips

### DIFF
--- a/scripts/darwin.sh
+++ b/scripts/darwin.sh
@@ -1,35 +1,43 @@
-#!/bin/sh
+#!/bin/bash
 
-function get_key {
+set -u
+set -e
+
+get_key() {
+
+  # This expression is intentionally unquoted so that
+  # multiple lines get joined as a single one.
+  # See https://github.com/resin-io-modules/drivelist/pull/129
   echo $(grep "$1" | awk -F "  +" '{ print $3 }')
+
 }
 
-function get_until_paren {
+get_until_paren() {
   awk 'match($0, "\\(|$"){ print substr($0, 0, RSTART - 1) }'
 }
 
-DISKS="`diskutil list | grep '^\/' | get_until_paren`"
-mount_output="`mount`"
+DISKS="$(diskutil list | grep '^\/' | get_until_paren)"
+mount_output="$(mount)"
 
 for disk in $DISKS; do
-  diskinfo="`diskutil info $disk`"
+  diskinfo="$(diskutil info "$disk")"
 
-  device=`echo "$diskinfo" | get_key "Device Node"`
+  device="$(echo "$diskinfo" | get_key "Device Node")"
 
   # See http://superuser.com/q/631592
-  raw_device=`echo "$device" | sed "s/disk/rdisk/g"`
+  raw_device="${device//disk/rdisk}"
 
-  description=`echo "$diskinfo" | get_key "Device / Media Name"`
-  volume_name=`echo "$diskinfo" | get_key "Volume Name"`
-  removable=`echo "$diskinfo" | get_key "Removable Media"`
-  protected=`echo "$diskinfo" | get_key "Read-Only Media"`
-  location=`echo "$diskinfo" | get_key "Device Location"`
-  size=`echo "$diskinfo" | sed 's/Disk Size/Total Size/g' | get_key "Total Size" | perl -n -e'/\((\d+)\sBytes\)/ && print $1'`
+  description="$(echo "$diskinfo" | get_key "Device / Media Name")"
+  volume_name="$(echo "$diskinfo" | get_key "Volume Name")"
+  removable="$(echo "$diskinfo" | get_key "Removable Media")"
+  protected="$(echo "$diskinfo" | get_key "Read-Only Media")"
+  location="$(echo "$diskinfo" | get_key "Device Location")"
+  size="$(echo "$diskinfo" | sed 's/Disk Size/Total Size/g' | get_key "Total Size" | perl -n -e'/\((\d+)\sBytes\)/ && print $1')"
 
-  mountpoints=`echo "$mount_output" | perl -n -e'm{^'"${disk}"'(s[0-9]+)? on (.*) \(.*\)$} && print "$2\n"'`
+  mountpoints="$(echo "$mount_output" | perl -n -e'm{^'"${disk}"'(s[0-9]+)? on (.*) \(.*\)$} && print "$2\n"')"
 
   # Omit mounted DMG images
-  if [ "$description" == "Disk Image" ]; then
+  if [[ "$description" == "Disk Image" ]]; then
     continue
   fi
 
@@ -45,11 +53,11 @@ for disk in $DISKS; do
 
   echo "size: $size"
 
-  if [ -z "$mountpoints" ]; then
+  if [[ -z "$mountpoints" ]]; then
     echo "mountpoints: []"
   else
     echo "mountpoints:"
-    echo "$mountpoints" | while read mountpoint ; do
+    echo "$mountpoints" | while read -r mountpoint ; do
       echo "  - path: $mountpoint"
     done
   fi


### PR DESCRIPTION
These were the addressed warnings:

```
In scripts/darwin.sh line 4:
  echo $(grep "$1" | awk -F "  +" '{ print $3 }')
       ^-- SC2046: Quote this to prevent word splitting.
       ^-- SC2005: Useless echo? Instead of 'echo $(cmd)', just use 'cmd'.

In scripts/darwin.sh line 11:
DISKS="`diskutil list | grep '^\/' | get_until_paren`"
       ^-- SC2006: Use $(..) instead of legacy `..`.

In scripts/darwin.sh line 12:
mount_output="`mount`"
              ^-- SC2006: Use $(..) instead of legacy `..`.

In scripts/darwin.sh line 15:
  diskinfo="`diskutil info $disk`"
            ^-- SC2006: Use $(..) instead of legacy `..`.
                           ^-- SC2086: Double quote to prevent globbing and word splitting.

In scripts/darwin.sh line 17:
  device=`echo "$diskinfo" | get_key "Device Node"`
         ^-- SC2006: Use $(..) instead of legacy `..`.

In scripts/darwin.sh line 20:
  raw_device=`echo "$device" | sed "s/disk/rdisk/g"`
             ^-- SC2006: Use $(..) instead of legacy `..`.
              ^-- SC2001: See if you can use ${variable//search/replace} instead.

In scripts/darwin.sh line 22:
  description=`echo "$diskinfo" | get_key "Device / Media Name"`
              ^-- SC2006: Use $(..) instead of legacy `..`.

In scripts/darwin.sh line 23:
  volume_name=`echo "$diskinfo" | get_key "Volume Name"`
              ^-- SC2006: Use $(..) instead of legacy `..`.

In scripts/darwin.sh line 24:
  removable=`echo "$diskinfo" | get_key "Removable Media"`
            ^-- SC2006: Use $(..) instead of legacy `..`.

In scripts/darwin.sh line 25:
  protected=`echo "$diskinfo" | get_key "Read-Only Media"`
            ^-- SC2006: Use $(..) instead of legacy `..`.

In scripts/darwin.sh line 26:
  location=`echo "$diskinfo" | get_key "Device Location"`
           ^-- SC2006: Use $(..) instead of legacy `..`.

In scripts/darwin.sh line 27:
  size=`echo "$diskinfo" | sed 's/Disk Size/Total Size/g' | get_key "Total Size" | perl -n -e'/\((\d+)\sBytes\)/ && print $1'`
       ^-- SC2006: Use $(..) instead of legacy `..`.

In scripts/darwin.sh line 29:
  mountpoints=`echo "$mount_output" | perl -n -e'm{^'"${disk}"'(s[0-9]+)? on (.*) \(.*\)$} && print "$2\n"'`
              ^-- SC2006: Use $(..) instead of legacy `..`.

In scripts/darwin.sh line 52:
    echo "$mountpoints" | while read mountpoint ; do
                                ^-- SC2162: read without -r will mangle backslashes.
```

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>