### PR TITLE
Print stderr script output to stderr if exit code is non zero

### DIFF
--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -18,6 +18,7 @@
 
 const childProcess = require('child_process');
 const path = require('path');
+const debug = require('debug')(require('../package.json').name);
 
 /**
  * @summary Absolute path to platform scripts
@@ -86,8 +87,12 @@ exports.run = (script, callback) => {
       return callback(error);
     }
 
+    // Don't throw an error if we get `stderr` output from
+    // the drive detection scripts at this point, given that
+    // if the script already exitted with code zero, then
+    // we consider them warnings that we can safely ignore.
     if (stderr.trim().length) {
-      return callback(new Error(stderr));
+      debug('stderr: %s', stderr);
     }
 
     return callback(null, stdout);

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "mochainon": "^1.0.0"
   },
   "dependencies": {
+    "debug": "^2.6.0",
     "js-yaml": "^3.4.1",
     "lodash": "^4.16.4"
   }

--- a/tests/scripts.spec.js
+++ b/tests/scripts.spec.js
@@ -67,22 +67,21 @@ describe('Scripts', function() {
 
     });
 
-    describe('given the script outputs to stderr', function() {
+    describe('given the script outputs to stderr with exit code 0', function() {
 
       beforeEach(function() {
         this.childProcessExecFileStub = m.sinon.stub(childProcess, 'execFile');
-        this.childProcessExecFileStub.yields(null, '', 'script error');
+        this.childProcessExecFileStub.yields(null, 'foo bar', 'script error');
       });
 
       afterEach(function() {
         this.childProcessExecFileStub.restore();
       });
 
-      it('should yield an error', function(done) {
+      it('should ignore stderr', function(done) {
         scripts.run('foo', (error, output) => {
-          m.chai.expect(error).to.be.an.instanceof(Error);
-          m.chai.expect(error.message).to.equal('script error');
-          m.chai.expect(output).to.not.exist;
+          m.chai.expect(error).to.not.exist;
+          m.chai.expect(output).to.equal('foo bar');
           done();
         });
       });


### PR DESCRIPTION
Platform scripts might output warnings to `stderr` that we don't want to
take into consideration if the script exits with an exit code 0.

If the scripts exits with a non-zero code, `.execFile()` yields an error
whose message includes the `stderr` output, so we don't need to do
anything ourselves.

See: https://github.com/resin-io/etcher/issues/1034
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>