### PR TITLE
Filter out invalid mountpoints on Windows

### DIFF
--- a/scripts/win32.bat
+++ b/scripts/win32.bat
@@ -84,9 +84,16 @@ Function GetLogicalDisks(ByVal DriveDevice)
 
 		For Each DriveLogicalDisk In DriveLogicalDisksColumn
 			Set LogicalDisk = CreateObject("Scripting.Dictionary")
-			LogicalDisk.Add "Device", DriveLogicalDisk.DeviceID
-			LogicalDisk.Add "IsProtected", DriveLogicalDisk.Access = 1
-			GetLogicalDisks.Add(LogicalDisk)
+
+			' Windows might assign a drive letter to partitions that
+			' don't contain a file-system for some reason.
+			' After some experimentation, it seems that we can filter
+			' those out by checking if the partition size is null
+			If Not IsNull(DriveLogicalDisk.Size) Then
+				LogicalDisk.Add "Device", DriveLogicalDisk.DeviceID
+				LogicalDisk.Add "IsProtected", DriveLogicalDisk.Access = 1
+				GetLogicalDisks.Add(LogicalDisk)
+			End If
 		Next
 	Next
 End Function


### PR DESCRIPTION
Turns out that when using certain hubs/multi SD Card adaptors, usually
in combination with images containing multiple partitions (which some
are unreadable by Windows), Windows will assign drive letters to
partitions that according to the operating system, have "no
file-system".

This means that if you go to My PC and try to open one of these invalid
drive letters, you get a nasty error, so its completely useless.

This proves problematic when we use the output of this module to safely
eject a drive, since we might try to eject an invalid drive letter,
resulting in more difficult to track errors.

After some investigation, it seems that we reliably identify these
drive letters by checking if the partition size is null.

See: https://github.com/resin-io/etcher/issues/1019
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>