### PR TITLE
Omit empty internal SD Card readers on Windows

### DIFF
--- a/scripts/win32.bat
+++ b/scripts/win32.bat
@@ -135,7 +135,13 @@ Function GetTopLevelDrives()
 		Summary.Add "IsRemovable", IsRemovable
 		Summary.Add "IsProtected", IsProtected
 
-		GetTopLevelDrives.Add(Summary)
+		' Windows might always list internal SD Card
+		' readers, even when there are no cards inserted.
+		' A realiable way to omit these drives is to
+		' check whether the size is null
+		If Not IsNull(Summary.Item("Size")) Then
+			GetTopLevelDrives.Add(Summary)
+		End If
 	Next
 End Function
 


### PR DESCRIPTION
Windows lists internal SD Card readers by default, even when they have
no SD Card inserted on them. As a solution, we can check if the size
returned for such internal reader is `null`, and if so, omit it from the
final drive list.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>