### PR TITLE
Implement drivelist.get()

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,18 +191,23 @@ $ npm install --save drivelist
 Documentation
 -------------
 
+
+* [drivelist](#module_drivelist)
+    * [.list(callback)](#module_drivelist.list)
+    * [.get(device, callback)](#module_drivelist.get)
+
 <a name="module_drivelist.list"></a>
 
 ### drivelist.list(callback)
-**Kind**: static method of <code>[drivelist](#module_drivelist)</code>
-**Summary**: List available drives
-**Access:** public
+**Kind**: static method of <code>[drivelist](#module_drivelist)</code>  
+**Summary**: List available drives  
+**Access:** public  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | callback | <code>function</code> | callback (error, drives) |
 
-**Example**
+**Example**  
 ```js
 const drivelist = require('drivelist');
 
@@ -214,6 +219,30 @@ drivelist.list((error, drives) => {
   drives.forEach((drive) => {
     console.log(drive);
   });
+});
+```
+<a name="module_drivelist.get"></a>
+
+### drivelist.get(device, callback)
+**Kind**: static method of <code>[drivelist](#module_drivelist)</code>  
+**Summary**: Get information about a drive  
+**Access:** public  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| device | <code>String</code> | drive device |
+| callback | <code>function</code> | callback (error, drive) |
+
+**Example**  
+```js
+const drivelist = require('drivelist');
+
+drivelist.get('\\\\.\\PHYSICALDRIVE2', (error, drive) => {
+  if (error) {
+    throw error;
+  }
+
+  console.log(drive);
 });
 ```
 

--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -17,6 +17,53 @@ Supports:
 - GNU/Linux distributions that include [util-linux](https://github.com/karelzak/util-linux) and [udev](https://wiki.archlinux.org/index.php/udev).
 - Mac OS X.
 
+The `drivelist` core consists of a set of scripts built with technologies that
+are available by default on the target operating systems (like Bash, VBScript,
+etc). Each of these scripts attempts to get information about the available
+drives (and metadata related to them), using any methods the target platform
+provides, like a combination of `diskutil`, `/proc/mounts`, etc. You can find
+these scripts in the `scripts/` directory.
+
+The scripts are then expected to print to `stdout` all the drive information
+they have gathered in a predefined way, based on the [YAML][yaml] language. The
+scripts are expected to output a set of blocks (separated by blank lines), each
+representing a drive with a set of key/value pairs. The exact keys that we
+expect are constantly changing while we keep improving this module, but you can
+see what the currently expected keys are by running the platform script that
+corresponds to your operating system.
+
+This is how the raw output looks on my MacBook Pro at the time of this writing:
+
+```sh
+$ ./scripts/darwin.sh
+device: /dev/disk0
+description: "APPLE SSD SM0256G"
+size: 251000193024
+mountpoints: []
+raw: /dev/rdisk0
+protected: False
+system: True
+
+device: /dev/disk1
+description: "Macintosh HD"
+size: 249779191808
+mountpoints:
+  - path: /
+raw: /dev/rdisk1
+protected: False
+system: True
+```
+
+Because of the simplicity of this module's design, supporting a new operating
+system simply means adding a new script to `scripts/` that gathers drive data
+and outputs something similar to the above example. The challenge with this is
+that we must ensure all the platform scripts print consistent output.
+
+When the user executes `drivelist.list()`, the module checks the operating
+system of the client, and executes the corresponding drive scanning script as a
+child process. It then parses the [YAML][yaml] output of the script as an array
+of objects, and returns that to the user.
+
 Examples (the output will vary depending on your machine):
 
 ```js
@@ -183,3 +230,5 @@ License
 -------
 
 The project is licensed under the Apache 2.0 license.
+
+[yaml]: http://yaml.org

--- a/lib/drivelist.js
+++ b/lib/drivelist.js
@@ -61,3 +61,43 @@ exports.list = (callback) => {
     return callback(null, parse(output));
   });
 };
+
+/**
+ * @summary Get information about a drive
+ * @function
+ * @public
+ *
+ * @param {String} device - drive device
+ * @param {Function} callback - callback (error, drive)
+ *
+ * @example
+ * const drivelist = require('drivelist');
+ *
+ * drivelist.get('\\\\.\\PHYSICALDRIVE2', (error, drive) => {
+ *   if (error) {
+ *     throw error;
+ *   }
+ *
+ *   console.log(drive);
+ * });
+ */
+exports.get = (device, callback) => {
+  exports.list((error, drives) => {
+    if (error) {
+      return callback(error);
+    }
+
+    const result = drives.find((drive) => {
+
+      // Case insensitive comparison
+      return drive.device.toLowerCase() === device.toLowerCase();
+
+    });
+
+    if (!result) {
+      return callback(new Error(`Drive not found: ${device}`));
+    }
+
+    return callback(null, result);
+  });
+};

--- a/tests/drivelist.spec.js
+++ b/tests/drivelist.spec.js
@@ -166,4 +166,105 @@ describe('Drivelist', function() {
 
   });
 
+  describe('.get()', function() {
+
+    describe('given scripts run succesfully', function() {
+
+      beforeEach(function() {
+        this.scriptsRunStub = m.sinon.stub(scripts, 'run');
+
+        this.scriptsRunStub.yields(null, [
+          'device: "\\\\\\\\.\\\\PHYSICALDRIVE1"',
+          'description: "My system drive"',
+          'size: 1073741824',
+          'mountpoints:',
+          '  - path: "C:"',
+          '',
+          'device: "\\\\\\\\.\\\\PHYSICALDRIVE2"',
+          'description: "My drive"',
+          'size: 33554432',
+          'mountpoints:',
+          '  - path: "D:"',
+          '  - path: "F:"'
+        ].join('\n'));
+      });
+
+      afterEach(function() {
+        this.scriptsRunStub.restore();
+      });
+
+      it('should find a drive', function(done) {
+        drivelist.get('\\\\.\\PHYSICALDRIVE1', function(error, drive) {
+          m.chai.expect(error).to.not.exist;
+          m.chai.expect(drive).to.deep.equal({
+            device: '\\\\.\\PHYSICALDRIVE1',
+            description: 'My system drive',
+            size: 1073741824,
+            mountpoints: [
+              {
+                path: 'C:'
+              }
+            ]
+          });
+
+          done();
+        });
+      });
+
+      it('should ignore casing', function(done) {
+        drivelist.get('\\\\.\\physicalDrive2', function(error, drive) {
+          m.chai.expect(error).to.not.exist;
+          m.chai.expect(drive).to.deep.equal({
+            device: '\\\\.\\PHYSICALDRIVE2',
+            description: 'My drive',
+            size: 33554432,
+            mountpoints: [
+              {
+                path: 'D:'
+              },
+              {
+                path: 'F:'
+              }
+            ]
+          });
+
+          done();
+        });
+      });
+
+      it('should throw if the drive was not found', function(done) {
+        drivelist.get('\\\\.\\PHYSICALDRIVE3', function(error, drive) {
+          m.chai.expect(error).to.be.an.instanceof(Error);
+          m.chai.expect(error.message).to.equal('Drive not found: \\\\.\\PHYSICALDRIVE3');
+          m.chai.expect(drive).to.not.exist;
+          done();
+        });
+      });
+
+    });
+
+    describe('given an unsupported os', function() {
+
+      beforeEach(function() {
+        this.osPlatformStub = m.sinon.stub(os, 'platform');
+        this.osPlatformStub.returns('foobar');
+      });
+
+      afterEach(function() {
+        this.osPlatformStub.restore();
+      });
+
+      it('should yield an unsupported error', function(done) {
+        drivelist.get('\\\\.\\PHYSICALDRIVE1', (error, drive) => {
+          m.chai.expect(error).to.be.an.instanceof(Error);
+          m.chai.expect(error.message).to.equal('Your OS is not supported by this module: foobar');
+          m.chai.expect(drive).to.not.exist;
+          done();
+        });
+      });
+
+    });
+
+  });
+
 });


### PR DESCRIPTION
This function allows the user to get information about a single drive.
Currently, this function runs the whole drive detection script and
filters the output, however in the future we might update the scripts to
take a drive argument, and only print information about that one, which
should be way faster.

See: https://github.com/resin-io/etcher/issues/750
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>