### PR TITLE
Bridge VBScript exit code to the caller on the Batch wrapper

### DIFF
--- a/scripts/win32.bat
+++ b/scripts/win32.bat
@@ -10,7 +10,7 @@
 set "PATH=%PATH%;%SYSTEMROOT%\System32"
 
 cscript //nologo "%~f0?.wsf"
-exit /b
+exit /b %ERRORLEVEL%
 
 ----- Begin wsf script --->
 <job><script language="VBScript">


### PR DESCRIPTION
If the Windows VBScript scanning script exits with a code other than 0,
the client that calls `win32.bat` will incorrectly think the script
finished successfully given that the Batch wrapper is not passing the
VBScript exit code to the caller.

See: https://github.com/resin-io/etcher/issues/1126
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>