### PR TITLE
Prevent errors when unplugging drives while the scripts are running

### DIFF
--- a/scripts/darwin.sh
+++ b/scripts/darwin.sh
@@ -20,7 +20,11 @@ DISKS="$(diskutil list | grep '^\/' | get_until_paren)"
 mount_output="$(mount)"
 
 for disk in $DISKS; do
-  diskinfo="$(diskutil info "$disk")"
+
+  # Ignore drives that were just unplugged
+  if ! diskinfo="$(diskutil info "$disk")"; then
+    continue
+  fi
 
   device="$(echo "$diskinfo" | get_key "Device Node")"
 

--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -26,6 +26,13 @@ for disk in $DISKS; do
 
   device="/dev/$disk"
   diskinfo=($(lsblk -b -d "$device" --output SIZE,RO,RM,MODEL | ignore_first_line))
+
+  # Omit drives for which `lsblk` failed, which means they
+  # were unplugged right after we got the list of all drives
+  if [ -z "${diskinfo-}" ]; then
+    continue
+  fi
+
   size=${diskinfo[0]}
   protected=${diskinfo[1]}
   removable=${diskinfo[2]}


### PR DESCRIPTION
macOS

- Check the `diskutil info` exit code

GNU/Linux

- Check the `diskinfo` list (thanks @Edudjr!)

Windows

- Create `IsWMIObjectValid` utility
- Make `GetLogicalDisks` return `Nothing` if the WMI query failed
- Check for `Nothing` in the main loop, and ignore the drive if that's
  the case

Fixes: https://github.com/resin-io-modules/drivelist/issues/147
See: https://github.com/resin-io/etcher/issues/1126
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>