### PR TITLE
Reset ERRORLEVEL at the beginning of win32.bat

### DIFF
--- a/scripts/win32.bat
+++ b/scripts/win32.bat
@@ -1,6 +1,9 @@
 <!-- : Begin batch script
 @echo off
 
+:: Reset ERRORLEVEL. See http://stackoverflow.com/a/1113735/1641422
+ver > nul
+
 :: Ensure System32 is in the PATH, to avoid weird
 :: 'cscript' is not recognized as an internal or external command"" errors.
 


### PR DESCRIPTION
Turns out ERRORLEVEL might carry errors from previous commands, given
that not every command resets it when exitting successfully.

This prevents us from getting false error alerts and helps us know for
sure that an exit code originated from drivelist.

See: https://github.com/resin-io/etcher/issues/1054
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>