### PR TITLE
Fix linux.sh and darwin.sh to always quote the mountpoint strings

### DIFF
--- a/scripts/darwin.sh
+++ b/scripts/darwin.sh
@@ -62,7 +62,7 @@ for disk in $DISKS; do
   else
     echo "mountpoints:"
     echo "$mountpoints" | while read -r mountpoint ; do
-      echo "  - path: $mountpoint"
+      echo "  - path: \"$mountpoint\""
     done
   fi
 

--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -66,7 +66,7 @@ for disk in $DISKS; do
   else
     echo "mountpoints:"
     echo "$mountpoints" | while read -r mountpoint ; do
-      echo "  - path: $mountpoint"
+      echo "  - path: \"$mountpoint\""
     done
   fi
 


### PR DESCRIPTION
This prevents the mountpoint strings being truncated when converted to JSON
if they happen to contain a `#` (the YAML quote character)

Fixes: #154
Change-type: patch