### PR TITLE
Fix linux.sh to work with mountpoints containing tab, newline or backslash

### DIFF
--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -12,7 +12,7 @@ get_uuids() {
 }
 
 get_mountpoints() {
-  grep "^$1" /proc/mounts | cut -d ' ' -f 2 | sed 's,\\040, ,g'
+  grep "^$1" /proc/mounts | cut -d ' ' -f 2 | sed 's,\\040, ,g' | sed 's,\\011,\t,g' | sed 's,\\012,\\n,g' | sed 's,\\134,\\\\,g'
 }
 
 DISKS="$(lsblk -d --output NAME | ignore_first_line)"


### PR DESCRIPTION
I tested mountpoints on Linux containing all kinds of weird characters, and `drivelist` now works properly with all of them. This is what running `node example.js` outputs:
```json
[
  {
    "device": "/dev/sda",
    "description": "SanDisk SD8SN8U1",
    "size": 1024209543168,
    "mountpoints": [
      {
        "path": "/"
      },
      {
        "path": "/boot/efi"
      },
      {
        "path": "/home"
      },
      {
        "path": "/var/lib/docker/aufs"
      }
    ],
    "raw": "/dev/sda",
    "protected": false,
    "system": true
  },
  {
    "device": "/dev/sdb",
    "description": "Cruzer",
    "size": 2018508288,
    "mountpoints": [
      {
        "path": "/tmp/dodgy/amp&dir"
      },
      {
        "path": "/tmp/dodgy/bs\\dir"
      },
      {
        "path": "/tmp/dodgy/dollar$dir"
      },
      {
        "path": "/tmp/dodgy/dq\"dir"
      },
      {
        "path": "/tmp/dodgy/hash#dir"
      },
      {
        "path": "/tmp/dodgy/hat^dir"
      },
      {
        "path": "/tmp/dodgy/nl\ndir"
      },
      {
        "path": "/tmp/dodgy/space dir"
      },
      {
        "path": "/tmp/dodgy/sq'dir"
      },
      {
        "path": "/tmp/dodgy/star*dir"
      },
      {
        "path": "/tmp/dodgy/tab\tdir"
      }
    ],
    "raw": "/dev/sdb",
    "protected": false,
    "system": false
  }
]
```

@jviotti I leave it up to you to make sure that `darwin.sh` works equally as well ;-)

Just for reference, here's the outputs of `scripts/linux.sh`:
```
device: /dev/sda
description: "SanDisk SD8SN8U1"
size: 1024209543168
mountpoints:
  - path: "/"
  - path: "/boot/efi"
  - path: "/home"
  - path: "/var/lib/docker/aufs"
raw: /dev/sda
protected: False
system: True

device: /dev/sdb
description: "Cruzer"
size: 2018508288
mountpoints:
  - path: "/tmp/dodgy/amp&dir"
  - path: "/tmp/dodgy/bs\\dir"
  - path: "/tmp/dodgy/dollar$dir"
  - path: "/tmp/dodgy/dq"dir"
  - path: "/tmp/dodgy/hash#dir"
  - path: "/tmp/dodgy/hat^dir"
  - path: "/tmp/dodgy/nl\ndir"
  - path: "/tmp/dodgy/space dir"
  - path: "/tmp/dodgy/sq'dir"
  - path: "/tmp/dodgy/star*dir"
  - path: "/tmp/dodgy/tab	dir"
raw: /dev/sdb
protected: False
system: False
```

and `cat /proc/mounts`:
```
sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
udev /dev devtmpfs rw,relatime,size=4022852k,nr_inodes=1005713,mode=755 0 0
devpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000 0 0
tmpfs /run tmpfs rw,nosuid,noexec,relatime,size=807880k,mode=755 0 0
/dev/sda4 / ext4 rw,relatime,errors=remount-ro,data=ordered 0 0
none /sys/fs/cgroup tmpfs rw,relatime,size=4k,mode=755 0 0
none /sys/fs/fuse/connections fusectl rw,relatime 0 0
none /sys/kernel/debug debugfs rw,relatime 0 0
none /sys/kernel/security securityfs rw,relatime 0 0
none /sys/firmware/efi/efivars efivarfs rw,relatime 0 0
none /run/lock tmpfs rw,nosuid,nodev,noexec,relatime,size=5120k 0 0
none /run/shm tmpfs rw,nosuid,nodev,relatime 0 0
none /run/user tmpfs rw,nosuid,nodev,noexec,relatime,size=102400k,mode=755 0 0
none /sys/fs/pstore pstore rw,relatime 0 0
cgroup /sys/fs/cgroup/cpuset cgroup rw,relatime,cpuset 0 0
cgroup /sys/fs/cgroup/cpu cgroup rw,relatime,cpu 0 0
cgroup /sys/fs/cgroup/cpuacct cgroup rw,relatime,cpuacct 0 0
cgroup /sys/fs/cgroup/memory cgroup rw,relatime,memory 0 0
cgroup /sys/fs/cgroup/devices cgroup rw,relatime,devices 0 0
cgroup /sys/fs/cgroup/freezer cgroup rw,relatime,freezer 0 0
cgroup /sys/fs/cgroup/net_cls cgroup rw,relatime,net_cls 0 0
cgroup /sys/fs/cgroup/blkio cgroup rw,relatime,blkio 0 0
cgroup /sys/fs/cgroup/perf_event cgroup rw,relatime,perf_event 0 0
cgroup /sys/fs/cgroup/net_prio cgroup rw,relatime,net_prio 0 0
cgroup /sys/fs/cgroup/hugetlb cgroup rw,relatime,hugetlb 0 0
/dev/sda1 /boot/efi vfat rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro 0 0
/dev/sda6 /home ext4 rw,relatime,errors=remount-ro,data=ordered 0 0
binfmt_misc /proc/sys/fs/binfmt_misc binfmt_misc rw,nosuid,nodev,noexec,relatime 0 0
systemd /sys/fs/cgroup/systemd cgroup rw,nosuid,nodev,noexec,relatime,name=systemd 0 0
/dev/sda4 /var/lib/docker/aufs ext4 rw,relatime,errors=remount-ro,data=ordered 0 0
gvfsd-fuse /run/user/1001/gvfs fuse.gvfsd-fuse rw,nosuid,nodev,relatime,user_id=1001,group_id=1001 0 0
/dev/sdb1 /tmp/dodgy/amp&dir vfat rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro 0 0
/dev/sdb1 /tmp/dodgy/bs\134dir vfat rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro 0 0
/dev/sdb1 /tmp/dodgy/dollar$dir vfat rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro 0 0
/dev/sdb1 /tmp/dodgy/dq"dir vfat rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro 0 0
/dev/sdb1 /tmp/dodgy/hash#dir vfat rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro 0 0
/dev/sdb1 /tmp/dodgy/hat^dir vfat rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro 0 0
/dev/sdb1 /tmp/dodgy/nl\012dir vfat rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro 0 0
/dev/sdb1 /tmp/dodgy/space\040dir vfat rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro 0 0
/dev/sdb1 /tmp/dodgy/sq'dir vfat rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro 0 0
/dev/sdb1 /tmp/dodgy/star*dir vfat rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro 0 0
/dev/sdb1 /tmp/dodgy/tab\011dir vfat rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro 0 0
```

Connects to #153 