### PR TITLE
Remove a useless string substitution and instead quote the string "inline"

### DIFF
--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -55,10 +55,9 @@ for disk in $DISKS; do
       description="$(cat "/sys/class/block/$subdevice/device/name")"
     fi
   fi
-  description="\"${description//"/\\"}\""
 
   echo "device: $device"
-  echo "description: $description"
+  echo "description: \"$description\""
   echo "size: $size"
 
   if [ -z "$mountpoints" ]; then


### PR DESCRIPTION
The `${description//"/\\"}` part isn't actually doing anything, because it's missing a backslash. I suspect it was _meant_ to be `${description//\"/\\\"}` but this isn't actually needed, as any embedded double-quotes actually get escaped by `lib/parse.js`, as I describe [here](https://github.com/resin-io-modules/drivelist/pull/156#issuecomment-288585161).