### PR TITLE
chore(editorconfig): Don't trim whitespace in Markdown

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
This avoids editors trimming whitespace in Markdown files,
preventing forced line endings (double-spaces) from being stripped.

Change-Type: patch