### PR TITLE
refactor(windows): Use an IOCTL to determine the partition type

### DIFF
--- a/src/windows/scanner.cc
+++ b/src/windows/scanner.cc
@@ -182,11 +182,6 @@ ScanMountpoints(drivelist::com::Connection *const connection,
   ULONG number;
 
   while (query.HasResult()) {
-    BOOL hasFilesystem;
-    result = query.HasPropertyString(L"FileSystem", &hasFilesystem);
-    if (FAILED(result))
-      return InterpretHRESULT(result);
-
     result = query.GetPropertyString(L"DriveLetter", &string);
     if (FAILED(result))
       return InterpretHRESULT(result);
@@ -199,6 +194,11 @@ ScanMountpoints(drivelist::com::Connection *const connection,
 
     std::string path = ConvertBSTRToString(string);
     SysFreeString(string);
+
+    BOOL hasFilesystem;
+    result = drivelist::volume::HasFileSystem(path[0], &hasFilesystem);
+    if (FAILED(result))
+      return InterpretHRESULT(result);
 
     ULONG typeNumber;
     result = query.GetPropertyNumber(L"DriveType", &typeNumber);

--- a/src/windows/volume.cc
+++ b/src/windows/volume.cc
@@ -65,6 +65,40 @@ HRESULT drivelist::volume::GetReadOnlyFlag(const wchar_t letter, BOOL *out) {
   return result;
 }
 
+HRESULT drivelist::volume::HasFileSystem(const wchar_t letter, BOOL *out) {
+  HANDLE handle = drivelist::volume::OpenHandle(letter, 0);
+  if (handle == INVALID_HANDLE_VALUE)
+    return E_HANDLE;
+
+  PARTITION_INFORMATION_EX information;
+  DWORD bytesReturned;
+
+  if (!DeviceIoControl(handle, IOCTL_DISK_GET_PARTITION_INFO_EX, NULL, 0,
+                       &information, sizeof(information),
+                       &bytesReturned, NULL)) {
+    return E_FAIL;
+  }
+
+  // See https://msdn.microsoft.com/en-us/library/windows/desktop/aa365448(v=vs.85).aspx
+  switch (information.PartitionStyle) {
+  case 0:  // MBR
+    *out = IsRecognizedPartition(information.Mbr.PartitionType);
+    break;
+  case 1:  // GPT
+
+    // TODO(jviotti): The Windows API documents a constant called
+    // PARTITION_ENTRY_UNUSED_GUID, but I can't find its definition anywhere.
+    *out = information.Gpt.PartitionType.Data1 != 0;
+
+    break;
+  default:  // RAW
+    *out = FALSE;
+  }
+
+  CloseHandle(handle);
+  return S_OK;
+}
+
 drivelist::volume::Type drivelist::volume::TranslateTypeNumber(ULONG type) {
   switch (type) {
   case 1:

--- a/src/windows/volume.h
+++ b/src/windows/volume.h
@@ -18,6 +18,7 @@
  */
 
 #include <windows.h>
+#include <Rpc.h>
 #include <vector>
 #include "src/mountpoint.h"
 #include "src/windows/com.h"
@@ -39,6 +40,7 @@ enum class Type {
 HANDLE OpenHandle(const wchar_t letter, DWORD flags);
 HRESULT GetDeviceNumber(const wchar_t letter, ULONG *out);
 HRESULT GetReadOnlyFlag(const wchar_t letter, BOOL *out);
+HRESULT HasFileSystem(const wchar_t letter, BOOL *out);
 Type TranslateTypeNumber(ULONG type);
 
 }  // namespace volume


### PR DESCRIPTION
This commit is part of some efforts to make use of IOCTLs directly and
get rid of WMI/COM altogether.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>