### PR TITLE
refactor(windows): Use an IOCTL to determine the partition type

### DIFF
--- a/src/windows/scanner.cc
+++ b/src/windows/scanner.cc
@@ -182,11 +182,6 @@ ScanMountpoints(drivelist::com::Connection *const connection,
   ULONG number;
 
   while (query.HasResult()) {
-    BOOL hasFilesystem;
-    result = query.HasPropertyString(L"FileSystem", &hasFilesystem);
-    if (FAILED(result))
-      return InterpretHRESULT(result);
-
     result = query.GetPropertyString(L"DriveLetter", &string);
     if (FAILED(result))
       return InterpretHRESULT(result);
@@ -199,6 +194,11 @@ ScanMountpoints(drivelist::com::Connection *const connection,
 
     std::string path = ConvertBSTRToString(string);
     SysFreeString(string);
+
+    BOOL hasFilesystem;
+    result = drivelist::volume::HasFileSystem(path[0], &hasFilesystem);
+    if (FAILED(result))
+      return InterpretHRESULT(result);
 
     // We only want to consider removable or local disks in this module
     drivelist::volume::Type volumeType = drivelist::volume::GetType(path[0]);

--- a/src/windows/volume.h
+++ b/src/windows/volume.h
@@ -18,6 +18,7 @@
  */
 
 #include <windows.h>
+#include <Rpc.h>
 #include <vector>
 #include "src/mountpoint.h"
 #include "src/windows/com.h"
@@ -39,6 +40,7 @@ enum class Type {
 HANDLE OpenHandle(const wchar_t letter, DWORD flags);
 HRESULT GetDeviceNumber(const wchar_t letter, ULONG *out);
 HRESULT GetReadOnlyFlag(const wchar_t letter, BOOL *out);
+HRESULT HasFileSystem(const wchar_t letter, BOOL *out);
 Type GetType(const wchar_t letter);
 
 }  // namespace volume


### PR DESCRIPTION
This commit is part of some efforts to make use of IOCTLs directly and
get rid of WMI/COM altogether.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>