### PR TITLE
fix(windows): detect read-only flag on SD Cards without a filesystem

### DIFF
--- a/src/windows/scanner.cc
+++ b/src/windows/scanner.cc
@@ -220,15 +220,23 @@ ScanMountpoints(drivelist::com::Connection *const connection,
     if (FAILED(result))
       return InterpretHRESULT(result);
 
-    BOOL isProtected;
-    result = drivelist::volume::GetReadOnlyFlag(path[0], &isProtected);
+    // Turns out a disk can be writable while its volumes can be read-only
+    // and viceversa, so we need to check the writable capabilities of
+    // both the disk and its volumes
+    BOOL writable;
+    result = drivelist::volume::IsDiskWritable(path[0], &writable);
     if (FAILED(result))
       return InterpretHRESULT(result);
+    if (writable && hasFilesystem) {
+      result = drivelist::volume::IsVolumeWritable(path[0], &writable);
+      if (FAILED(result))
+        return InterpretHRESULT(result);
+    }
 
     drivelist::mountpoint_s mountpoint;
     mountpoint.path = path;
     mountpoint.disk = "\\\\.\\PHYSICALDRIVE" + std::to_string(number);
-    mountpoint.readonly = isProtected;
+    mountpoint.readonly = !writable;
     mountpoint.system = path[0] == systemDriveLetter;
     mountpoint.hasFilesystem = hasFilesystem;
     output->push_back(mountpoint);

--- a/src/windows/volume.cc
+++ b/src/windows/volume.cc
@@ -44,25 +44,45 @@ HRESULT drivelist::volume::GetDeviceNumber(const wchar_t letter, ULONG *out) {
   return S_OK;
 }
 
-HRESULT drivelist::volume::GetReadOnlyFlag(const wchar_t letter, BOOL *out) {
-  DWORD filesystem_flags = 0;
-  TCHAR drive_path[kVolumePathShortLength];
-  sprintf_s(drive_path, "%c:\\", letter);
+HRESULT drivelist::volume::IsDiskWritable(const wchar_t letter, BOOL *out) {
+  HANDLE handle = drivelist::volume::OpenHandle(letter, 0);
+  if (handle == INVALID_HANDLE_VALUE)
+    return E_HANDLE;
 
-  const HRESULT result =
-      GetVolumeInformation(drive_path, NULL, kVolumePathShortLength, NULL, NULL,
-                           &filesystem_flags, NULL, 0);
+  DWORD bytesReturned;
 
-  if (FAILED(result))
-    return result;
+  // The IOCTL_DISK_IS_WRITABLE returns
+  // FALSE if the device is read-only
+  // See https://msdn.microsoft.com/en-us/library/windows/desktop/aa365182(v=vs.85).aspx
+  const BOOL isDiskWritable = DeviceIoControl(handle, IOCTL_DISK_IS_WRITABLE,
+                                              NULL, 0,
+                                              NULL, 0,
+                                              &bytesReturned, NULL);
 
-  if (filesystem_flags & FILE_READ_ONLY_VOLUME) {
+  *out = isDiskWritable;
+  CloseHandle(handle);
+  return S_OK;
+}
+
+HRESULT drivelist::volume::IsVolumeWritable(const wchar_t letter, BOOL *out) {
+  DWORD filesystemFlags = 0;
+  TCHAR drivePath[kVolumePathShortLength];
+  sprintf_s(drivePath, "%c:\\", letter);
+
+  BOOL result = GetVolumeInformation(drivePath, NULL,
+                                     0, NULL,
+                                     NULL, &filesystemFlags, NULL, 0);
+
+  if (!result)
+    return E_FAIL;
+
+  if (filesystemFlags & FILE_READ_ONLY_VOLUME) {
     *out = TRUE;
   } else {
     *out = FALSE;
   }
 
-  return result;
+  return S_OK;
 }
 
 drivelist::volume::Type drivelist::volume::TranslateTypeNumber(ULONG type) {

--- a/src/windows/volume.h
+++ b/src/windows/volume.h
@@ -38,7 +38,8 @@ enum class Type {
 
 HANDLE OpenHandle(const wchar_t letter, DWORD flags);
 HRESULT GetDeviceNumber(const wchar_t letter, ULONG *out);
-HRESULT GetReadOnlyFlag(const wchar_t letter, BOOL *out);
+HRESULT IsDiskWritable(const wchar_t letter, BOOL *out);
+HRESULT IsVolumeWritable(const wchar_t letter, BOOL *out);
 Type TranslateTypeNumber(ULONG type);
 
 }  // namespace volume


### PR DESCRIPTION
If an SD Card is locked, but contains no file-system,
GetVolumeInformation, opening a handle with write access, and even
IOCTL_DISK_GET_DISK_ATTRIBUTES would say that the volume is not locked.

Turns out we can use IOCTL_DISK_IS_WRITABLE, which returns the correct
answer.

See: https://github.com/resin-io/etcher/issues/1538
See: https://stackoverflow.com/a/44706760/1641422
Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>