### PR TITLE
fix(windows): detect read-only flag on SD Cards without a filesystem

### DIFF
--- a/src/windows/volume.h
+++ b/src/windows/volume.h
@@ -39,7 +39,8 @@ enum class Type {
 
 HANDLE OpenHandle(const wchar_t letter, DWORD flags);
 HRESULT GetDeviceNumber(const wchar_t letter, ULONG *out);
-HRESULT GetReadOnlyFlag(const wchar_t letter, BOOL *out);
+HRESULT IsDiskWritable(const wchar_t letter, BOOL *out);
+HRESULT IsVolumeWritable(const wchar_t letter, BOOL *out);
 HRESULT HasFileSystem(const wchar_t letter, BOOL *out);
 Type GetType(const wchar_t letter);
 


### PR DESCRIPTION
If an SD Card is locked, but contains no file-system,
GetVolumeInformation, opening a handle with write access, and even
IOCTL_DISK_GET_DISK_ATTRIBUTES would say that the volume is not locked.

The problem is that Windows makes a distinction between disks and
volumes, and a disk can be read-only even when its volumes are writable.

As a solution, we use a combination of IOCTL_DISK_IS_WRITABLE and
GetVolumeInformation().

See: https://github.com/resin-io/etcher/issues/1538
See: https://stackoverflow.com/a/44706760/1641422
Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>