### PR TITLE
fix(windows): all drives are interpreted as read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## v5.0.25 - 2017-06-29
 
 * Chore(package): Fix missing EOL in package.json [Jonas Hermsmeier]
+* Fix(windows): all drives are interpreted as read-only [Juan Cruz Viotti]
 * Fix(windows): detect read-only flag on SD Cards without a filesystem (#183) [Juan Cruz Viotti]
 * Refactor(windows): Use an IOCTL to determine the partition type (#181) [Juan Cruz Viotti]
 

--- a/src/windows/scanner.cc
+++ b/src/windows/scanner.cc
@@ -220,7 +220,7 @@ ScanMountpoints(drivelist::com::Connection *const connection,
     result = drivelist::volume::IsDiskWritable(path[0], &writable);
     if (FAILED(result))
       return InterpretHRESULT(result);
-    if (writable && hasFilesystem) {
+    if (!writable && hasFilesystem) {
       result = drivelist::volume::IsVolumeWritable(path[0], &writable);
       if (FAILED(result))
         return InterpretHRESULT(result);

--- a/src/windows/volume.cc
+++ b/src/windows/volume.cc
@@ -86,38 +86,26 @@ HRESULT drivelist::volume::IsVolumeWritable(const wchar_t letter, BOOL *out) {
 }
 
 HRESULT drivelist::volume::HasFileSystem(const wchar_t letter, BOOL *out) {
-  HANDLE handle = drivelist::volume::OpenHandle(letter, 0);
-  if (handle == INVALID_HANDLE_VALUE)
-    return E_HANDLE;
-
-  PARTITION_INFORMATION_EX information;
-  DWORD bytesReturned;
-
-  if (!DeviceIoControl(handle, IOCTL_DISK_GET_PARTITION_INFO_EX, NULL, 0,
-                       &information, sizeof(information),
-                       &bytesReturned, NULL)) {
-    CloseHandle(handle);
-    return E_FAIL;
+  TCHAR drivePath[kVolumePathShortLength];
+  sprintf_s(drivePath, "%c:\\", letter);
+  BOOL result = GetVolumeInformation(drivePath, NULL, 0, NULL,
+                                     NULL, NULL, NULL, 0);
+  if (result) {
+    *out = TRUE;
+    return S_OK;
   }
 
-  // See https://msdn.microsoft.com/en-us/library/windows/desktop/aa365448(v=vs.85).aspx
-  switch (information.PartitionStyle) {
-  case 0:  // MBR
-    *out = IsRecognizedPartition(information.Mbr.PartitionType);
-    break;
-  case 1:  // GPT
+  DWORD error = GetLastError();
 
-    // TODO(jviotti): The Windows API documents a constant called
-    // PARTITION_ENTRY_UNUSED_GUID, but I can't find its definition anywhere.
-    *out = information.Gpt.PartitionType.Data1 != 0;
-
-    break;
-  default:  // RAW
+  // ERROR_UNRECOGNIZED_VOLUME: when there is a partition table, but
+  // no actual recognized partition
+  // ERROR_INVALID_PARAMETER: when there is no partition table at all
+  if (error == ERROR_UNRECOGNIZED_VOLUME || error == ERROR_INVALID_PARAMETER) {
     *out = FALSE;
+    return S_OK;
   }
 
-  CloseHandle(handle);
-  return S_OK;
+  return HRESULT_FROM_WIN32(error);
 }
 
 drivelist::volume::Type drivelist::volume::GetType(const wchar_t letter) {


### PR DESCRIPTION
This was an accidental subtle logical flaw in the PR where we check both
the disk and the volume writable state.

We only want to consider the volumes writable state if the disk is
read-only, and the volumes have a file-system.

Change-Type: patch
See: https://github.com/resin-io-modules/drivelist/pull/183
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>