### PR TITLE
fix(windows): report a more accurate drive size number

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -14,6 +14,7 @@
             "src/windows/com.cc",
             "src/windows/scanner.cc",
             "src/windows/volume.cc",
+            "src/windows/disk.cc",
             "src/windows/wmi.cc"
           ],
           "libraries": [

--- a/src/windows/disk.cc
+++ b/src/windows/disk.cc
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/windows/disk.h"
+
+HRESULT drivelist::disk::GetSize(std::string disk, LONGLONG *out) {
+  HANDLE handle = CreateFile(disk.c_str(), 0, FILE_SHARE_READ, NULL,
+                             OPEN_EXISTING, 0, NULL);
+  if (handle == INVALID_HANDLE_VALUE)
+    return E_HANDLE;
+
+  DISK_GEOMETRY_EX geometry;
+  DWORD bytesReturned;
+
+  BOOL success = DeviceIoControl(handle, IOCTL_DISK_GET_DRIVE_GEOMETRY_EX,
+                                 NULL, 0,
+                                 &geometry, sizeof(geometry),
+                                 &bytesReturned, NULL);
+  if (!success) {
+    HRESULT result = HRESULT_FROM_WIN32(GetLastError());
+
+    // This error represents "the device is not ready", and will
+    // occur on SD Card readers that don't have an SD Card plugged in.
+    // The documentation explicitly states that the ERROR_NOT_READY
+    // constant is equal to this hexadecimal number, but it doesn't
+    // seem to be the case.
+    if (result == 0x80070015) {
+      *out = NULL;
+      return S_OK;
+    }
+
+    return result;
+  }
+
+  *out = geometry.DiskSize.QuadPart;
+  return S_OK;
+}

--- a/src/windows/disk.h
+++ b/src/windows/disk.h
@@ -1,0 +1,31 @@
+#ifndef SRC_WINDOWS_DISK_H_
+#define SRC_WINDOWS_DISK_H_
+
+/*
+ * Copyright 2017 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <windows.h>
+#include <string>
+
+namespace drivelist {
+namespace disk {
+
+HRESULT GetSize(std::string disk, LONGLONG *out);
+
+}  // namespace disk
+}  // namespace drivelist
+
+#endif  // SRC_WINDOWS_DISK_H_


### PR DESCRIPTION
We were using WMI to get the size of a physical drive, however turns out
that is number is not very accurate (since its based on CHS), and even
plain wrong in some cases.

As a solution, we now use the IOCTL_DISK_GET_DRIVE_GEOMETRY_EX ioctl to
get the size of a physical drive.

See: https://github.com/resin-io/etcher/issues/995
See: https://github.com/resin-io/etcher/issues/1483
Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>