### PR TITLE
fix(windows): ERROR_NOT_READY on empty SD Card reader

### DIFF
--- a/src/windows/volume.cc
+++ b/src/windows/volume.cc
@@ -130,7 +130,10 @@ HRESULT drivelist::volume::HasFileSystem(const wchar_t letter, BOOL *out) {
   // ERROR_UNRECOGNIZED_VOLUME: when there is a partition table, but
   // no actual recognized partition
   // ERROR_INVALID_PARAMETER: when there is no partition table at all
-  if (error == ERROR_UNRECOGNIZED_VOLUME || error == ERROR_INVALID_PARAMETER) {
+  // ERROR_NOT_READY: when accessing an empty SD Card reader
+  if (error == ERROR_UNRECOGNIZED_VOLUME ||
+      error == ERROR_INVALID_PARAMETER ||
+      error == ERROR_NOT_READY) {
     *out = FALSE;
     return S_OK;
   }


### PR DESCRIPTION
This error occurs when calling `GetVolumeInformation()` on a volume that
maps to an internal SD Card reader without an SD Card inside.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>