### PR TITLE
fix(windows): match bindings.gyp casing when loading the native module

### DIFF
--- a/lib/drivelist.js
+++ b/lib/drivelist.js
@@ -50,7 +50,7 @@ exports.list = (callback) => {
   const operatingSystem = os.platform();
 
   if (operatingSystem === 'win32') {
-    bindings('Drivelist').list(callback);
+    bindings('drivelist').list(callback);
     return;
   }
 


### PR DESCRIPTION
The target name of bindings.gyp is "drivelist" however in the JavaScript
code, we're loading it as "Drivelist." This works on development mode,
since on Windows, file paths are case insensitive, however when packaged
inside an asar, casing matters.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>