### PR TITLE
fix(execute): Properly clean up tmp file after exec

### DIFF
--- a/lib/execute.js
+++ b/lib/execute.js
@@ -16,13 +16,30 @@
 
 'use strict';
 
-const debug = require('debug')(require('../package.json').name);
-const Bluebird = require('bluebird');
-const fs = Bluebird.promisifyAll(require('fs'));
+const packageInfo = require('../package.json');
+const debug = require('debug')(packageInfo.name);
+const fs = require('fs');
 const childProcess = require('child_process');
 const path = require('path');
-const tmp = require('tmp');
-tmp.setGracefulCleanup();
+const os = require('os');
+const crypto = require('crypto');
+
+/**
+ * @summary Generate a tmp filename with full path of OS' tmp dir
+ * @function
+ * @private
+ *
+ * @param {String} extension - temporary file extension
+ * @returns {String} filename
+ *
+ * @example
+ * const filename = tmpFilename('.sh');
+ */
+const tmpFilename = (extension) => {
+  const random = crypto.randomBytes(6).toString('hex');
+  const filename = `${packageInfo.name}-${random}${extension}`;
+  return path.join(os.tmpdir(), filename);
+};
 
 /**
  * @summary Create a temporary script file with the given contents
@@ -31,35 +48,36 @@ tmp.setGracefulCleanup();
  *
  * @param {String} extension - temporary script file extension
  * @param {String} contents - temporary script contents
- * @fulfil {String} - temporary script file path
- * @returns {Promise}
+ * @param {Function} callback - callback(error, temporaryPath)
  *
  * @example
- * createTemporaryScriptFile('.sh', '#!/bin/bash\necho "Foo"').then((temporaryPath) => {
+ * createTemporaryScriptFile('.sh', '#!/bin/bash\necho "Foo"', (error, temporaryPath) => {
+ *   if (error) {
+ *     throw error;
+ *   }
  *   console.log(temporaryPath);
  * })
  */
-const createTemporaryScriptFile = (extension, contents) => {
-  return new Bluebird((resolve, reject) => {
-    tmp.file({
-      postfix: extension,
+const createTemporaryScriptFile = (extension, contents, callback) => {
+  const temporaryPath = tmpFilename(extension);
+  fs.writeFile(temporaryPath, contents, {
+    mode: 0o755
+  }, (error) => {
+    debug('write %s:', temporaryPath, error || 'OK');
+    callback(error, temporaryPath);
+  });
+};
 
-      // 0755 to decimal, because strict
-      // mode disallows octal literals
-      mode: 493
-
-    }, (error, temporaryPath, fileDescriptor) => {
-      if (error) {
-        return reject(error);
-      }
-
-      return fs.writeFileAsync(fileDescriptor, contents)
-        .return(fileDescriptor)
-        .then(fs.closeAsync)
-        .return(temporaryPath)
-        .then(resolve)
-        .catch(reject);
-    });
+/**
+ * @summary Delete a file while ignoring any errors
+ * @function
+ * @private
+ *
+ * @param {String} filename - file path
+ */
+const deleteTempFile = (filename) => {
+  fs.unlink(filename, (error) => {
+    debug('unlink', error || 'OK');
   });
 };
 
@@ -71,7 +89,7 @@ const createTemporaryScriptFile = (extension, contents) => {
  * @param {Object} script - script
  * @param {String} script.content - script content
  * @param {String} script.originalFilename - script original filename
- * @param {Function} callback - callback (error, output)
+ * @param {Function} callback - callback(error, output)
  *
  * @example
  * scripts.run({
@@ -86,35 +104,40 @@ const createTemporaryScriptFile = (extension, contents) => {
  * });
  */
 exports.extractAndRun = (script, callback) => {
+
   const extension = path.extname(script.originalFilename);
-  createTemporaryScriptFile(extension, script.content).then((temporaryPath) => {
-    return new Bluebird((resolve, reject) => {
 
-      // On Windows, if the directory containing the temporary
-      // path includes an ampersand (e.g. if the username contains
-      // an ampersand) then `.execFile` will fail, even with proper
-      // quoting, which is why we're using `.exec` instead.
-      return childProcess.exec(`"${temporaryPath}"`, (error, stdout, stderr) => {
-        if (error) {
+  createTemporaryScriptFile(extension, script.content, (writeError, temporaryPath) => {
 
-          // For debugging purposes
-          error.message += ` (code ${error.code})`;
-          debug('stderr: %s', stderr);
-          debug('stdout: %s', stdout);
+    if (writeError) {
+      return callback(writeError);
+    }
 
-          return reject(error);
-        }
+    childProcess.execFile(temporaryPath, {
+      timeout: 10 * 1000
+    }, (error, stdout, stderr) => {
 
-        // Don't throw an error if we get `stderr` output from
-        // the drive detection scripts at this point, given that
-        // if the script already exitted with code zero, then
-        // we consider them warnings that we can safely ignore.
-        if (stderr.trim().length) {
-          debug('stderr: %s', stderr);
-        }
+      // Attempt to clean up, but ignore failure
+      deleteTempFile(temporaryPath);
 
-        return resolve(stdout);
-      });
+      if (error) {
+        error.message += ` (code ${error.code}, signal ${error.signal || 'none'})`;
+        debug('error:', error);
+        debug('stderr: %s', stderr);
+        debug('stdout: %s', stdout);
+        return callback(error);
+      }
+
+      // Don't throw an error if we get `stderr` output from
+      // the drive detection scripts at this point, given that
+      // if the script already exitted with code zero, then
+      // we consider them warnings that we can safely ignore.
+      if (stderr.trim().length) {
+        debug('stderr: %s', stderr);
+      }
+
+      callback(null, stdout);
+
     });
-  }).asCallback(callback);
+  });
 };

--- a/package.json
+++ b/package.json
@@ -43,12 +43,10 @@
     "mochainon": "^1.0.0"
   },
   "dependencies": {
-    "bluebird": "^3.5.0",
+    "bindings": "^1.2.1",
     "debug": "^2.6.0",
     "js-yaml": "^3.4.1",
     "lodash": "^4.16.4",
-    "tmp": "0.0.31",
-    "bindings": "^1.2.1",
     "nan": "^2.6.2"
   }
 }

--- a/tests/execute.spec.js
+++ b/tests/execute.spec.js
@@ -71,7 +71,7 @@ describe('Execute', function() {
           originalFilename: 'foo'
         }, (error, output) => {
           m.chai.expect(error).to.be.an.instanceof(Error);
-          m.chai.expect(error.message).to.equal('script error (code 27)');
+          m.chai.expect(error.message).to.equal('script error (code 27, signal none)');
           m.chai.expect(output).to.not.exist;
           done();
         });


### PR DESCRIPTION
This fixes temporary files not being cleaned up after execution.
See https://github.com/resin-io/etcher/issues/1571 for extensive details.

Changes:

- Use `os.tmpdir()` to get temporary file directory
- Prefix tmp file with package name for better identification
- Delete tmp file after use
- Add execution timeout of 10s
- Add debug statements for write & unlink
- Add process signal to error message
- Remove `tmp` and `bluebird` dependencies

Change-Type: patch
Connects To: #190, https://github.com/resin-io/etcher/issues/1571