### PR TITLE
feat(windows): print debugging information when DRIVELIST_DEBUG is set

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -7,7 +7,8 @@
         "."
       ],
       "sources": [
-        "src/code.cc"
+        "src/code.cc",
+        "src/log.cc"
       ],
       "conditions": [
         [ 'OS=="win"', {

--- a/src/log.cc
+++ b/src/log.cc
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/log.h"
+
+void drivelist::Debug(const std::string &string) {
+  const char* debug = std::getenv("DRIVELIST_DEBUG");
+  if (debug != NULL) {
+    std::cout << "[drivelist] " << string << std::endl;
+  }
+}

--- a/src/log.h
+++ b/src/log.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_LOG_H_
+#define SRC_LOG_H_
+
+#include <string>
+#include <iostream>
+
+namespace drivelist {
+
+void Debug(const std::string &string);
+
+}  // namespace drivelist
+
+
+#endif  // SRC_LOG_H_

--- a/src/windows/com.cc
+++ b/src/windows/com.cc
@@ -15,16 +15,17 @@
  */
 
 #include "src/windows/com.h"
+#include "src/log.h"
 
 HRESULT drivelist::com::Initialize() {
   HRESULT result;
 
-  // Initialize COM
+  drivelist::Debug("Initializing COM");
   result = CoInitializeEx(NULL, COINIT_MULTITHREADED);
   if (FAILED(result))
     return result;
 
-  // Set general COM security levels
+  drivelist::Debug("Initializing COM security levels");
   result = CoInitializeSecurity(
     NULL,                         // Security descriptor
     -1,                           // COM authentication
@@ -58,6 +59,7 @@ drivelist::com::Connection::~Connection() {
 }
 
 HRESULT drivelist::com::Connection::Connect(const LPCWSTR server) {
+  drivelist::Debug("Connecting to server");
   const HRESULT result = this->locator->ConnectServer(
     _bstr_t(server),         // Path to server
     NULL,                    // User name. NULL = current user
@@ -72,7 +74,7 @@ HRESULT drivelist::com::Connection::Connect(const LPCWSTR server) {
     return result;
   }
 
-  // Set sensible proxy security levels
+  drivelist::Debug("Setting proxy security levels");
   return CoSetProxyBlanket(
     this->proxy,                  // Indicates the proxy to set
     RPC_C_AUTHN_WINNT,            // RPC_C_AUTHN_xxx
@@ -85,6 +87,7 @@ HRESULT drivelist::com::Connection::Connect(const LPCWSTR server) {
 }
 
 HRESULT drivelist::com::Connection::CreateInstance() {
+  drivelist::Debug("Creating connection instance");
   return CoCreateInstance(
     CLSID_WbemLocator,
     NULL,  // Not being created as part of an aggregate

--- a/src/windows/disk.cc
+++ b/src/windows/disk.cc
@@ -15,8 +15,10 @@
  */
 
 #include "src/windows/disk.h"
+#include "src/log.h"
 
 HRESULT drivelist::disk::GetSize(std::string disk, LONGLONG *out) {
+  drivelist::Debug("Opening handle on " + disk);
   HANDLE handle = CreateFile(disk.c_str(), 0, FILE_SHARE_READ, NULL,
                              OPEN_EXISTING, 0, NULL);
   if (handle == INVALID_HANDLE_VALUE)
@@ -25,6 +27,7 @@ HRESULT drivelist::disk::GetSize(std::string disk, LONGLONG *out) {
   DISK_GEOMETRY_EX geometry;
   DWORD bytesReturned;
 
+  drivelist::Debug("Getting drive geometry");
   BOOL success = DeviceIoControl(handle, IOCTL_DISK_GET_DRIVE_GEOMETRY_EX,
                                  NULL, 0,
                                  &geometry, sizeof(geometry),
@@ -38,6 +41,7 @@ HRESULT drivelist::disk::GetSize(std::string disk, LONGLONG *out) {
     // constant is equal to this hexadecimal number, but it doesn't
     // seem to be the case.
     if (result == 0x80070015) {
+      drivelist::Debug("Ignoring, device not ready");
       *out = NULL;
       return S_OK;
     }


### PR DESCRIPTION
Like we do on mountutils. Debugging native modules can be very tricky.
Printing a lot of info should help us to easily identify and fix issues.

Change-Type: minor
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>