### PR TITLE
fix: handle EAGAIN spawning errors

### DIFF
--- a/lib/execute.js
+++ b/lib/execute.js
@@ -69,20 +69,54 @@ const createTemporaryScriptFile = (extension, contents, callback) => {
 };
 
 /**
- * @summary Delete a file while ignoring any errors
+ * @summary Execute a script
  * @function
  * @private
  *
- * @param {String} filename - file path
- * @param {Function} callback - callback
+ * @param {String} scriptPath - script path
+ * @param {Function} callback - callback (error, output)
+ * @param {Number} [times=5] - retry times
+ *
+ * @example
+ * executeScript('path/to/script.sh', (error, output) => {
+ *   if (error) throw error;
+ *   console.log(output);
+ * });
  */
-const deleteTempFile = (filename, callback) => {
-  fs.unlink(filename, (error) => {
+const executeScript = (scriptPath, callback, times = 5) => {
+  childProcess.execFile(scriptPath, (error, stdout, stderr) => {
     if (error) {
-      debug('unlink', error);
+      if (error.code === 'EAGAIN') {
+        if (times <= 0) {
+          error.message = [
+            'Looks like you hit the limit of the number of process you can have at any given time,',
+            'so the child process needed to scan the available drives could not be spawned.'
+          ].join(' ');
+          return callback(error);
+        }
+
+        debug('Got EAGAIN, retrying...');
+        return setTimeout(() => {
+          executeScript(scriptPath, callback, times - 1);
+        }, 500);
+      }
+
+      error.message += ` (code ${error.code}, signal ${error.signal || 'none'})`;
+      debug('error:', error);
+      debug('stderr: %s', stderr);
+      debug('stdout: %s', stdout);
+      return callback(error);
     }
 
-    callback();
+    // Don't throw an error if we get `stderr` output from
+    // the drive detection scripts at this point, given that
+    // if the script already exitted with code zero, then
+    // we consider them warnings that we can safely ignore.
+    if (stderr.trim().length) {
+      debug('stderr: %s', stderr);
+    }
+
+    callback(null, stdout);
   });
 };
 
@@ -109,40 +143,22 @@ const deleteTempFile = (filename, callback) => {
  * });
  */
 exports.extractAndRun = (script, callback) => {
-
   const extension = path.extname(script.originalFilename);
 
   createTemporaryScriptFile(extension, script.content, (writeError, temporaryPath) => {
-
     if (writeError) {
       return callback(writeError);
     }
 
-    childProcess.execFile(temporaryPath, {
-      timeout: 10 * 1000
-    }, (error, stdout, stderr) => {
+    executeScript(temporaryPath, (executeError, output) => {
 
       // Attempt to clean up, but ignore failure
-      deleteTempFile(temporaryPath, () => {
-
-        if (error) {
-          error.message += ` (code ${error.code}, signal ${error.signal || 'none'})`;
-          debug('error:', error);
-          debug('stderr: %s', stderr);
-          debug('stdout: %s', stdout);
-          return callback(error);
+      fs.unlink(temporaryPath, (unlinkError) => {
+        if (unlinkError) {
+          debug('unlink error', unlinkError);
         }
 
-        // Don't throw an error if we get `stderr` output from
-        // the drive detection scripts at this point, given that
-        // if the script already exitted with code zero, then
-        // we consider them warnings that we can safely ignore.
-        if (stderr.trim().length) {
-          debug('stderr: %s', stderr);
-        }
-
-        callback(null, stdout);
-
+        callback(executeError, output);
       });
     });
   });


### PR DESCRIPTION
EAGAIN errors come from `uv_spawn()`, and may happen because of the
following reasons (from the man pages):

- The system-imposed limit on the total number of processes under
  execution would be exceeded. This limit is configuration-dependent

- The system-imposed limit MAXUPRC (<sys/param.h>) on the total number
  of processes under execution by a single user would be exceeded

This commit retries the spawning operation various times before giving
up with a human friendly error message.

See: https://github.com/resin-io/etcher/issues/1578
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>