### PR TITLE
refactor: reduce debug logging if unlink was successful

### DIFF
--- a/lib/execute.js
+++ b/lib/execute.js
@@ -74,10 +74,15 @@ const createTemporaryScriptFile = (extension, contents, callback) => {
  * @private
  *
  * @param {String} filename - file path
+ * @param {Function} callback - callback
  */
-const deleteTempFile = (filename) => {
+const deleteTempFile = (filename, callback) => {
   fs.unlink(filename, (error) => {
-    debug('unlink', error || 'OK');
+    if (error) {
+      debug('unlink', error);
+    }
+
+    callback();
   });
 };
 
@@ -118,26 +123,27 @@ exports.extractAndRun = (script, callback) => {
     }, (error, stdout, stderr) => {
 
       // Attempt to clean up, but ignore failure
-      deleteTempFile(temporaryPath);
+      deleteTempFile(temporaryPath, () => {
 
-      if (error) {
-        error.message += ` (code ${error.code}, signal ${error.signal || 'none'})`;
-        debug('error:', error);
-        debug('stderr: %s', stderr);
-        debug('stdout: %s', stdout);
-        return callback(error);
-      }
+        if (error) {
+          error.message += ` (code ${error.code}, signal ${error.signal || 'none'})`;
+          debug('error:', error);
+          debug('stderr: %s', stderr);
+          debug('stdout: %s', stdout);
+          return callback(error);
+        }
 
-      // Don't throw an error if we get `stderr` output from
-      // the drive detection scripts at this point, given that
-      // if the script already exitted with code zero, then
-      // we consider them warnings that we can safely ignore.
-      if (stderr.trim().length) {
-        debug('stderr: %s', stderr);
-      }
+        // Don't throw an error if we get `stderr` output from
+        // the drive detection scripts at this point, given that
+        // if the script already exitted with code zero, then
+        // we consider them warnings that we can safely ignore.
+        if (stderr.trim().length) {
+          debug('stderr: %s', stderr);
+        }
 
-      callback(null, stdout);
+        callback(null, stdout);
 
+      });
     });
   });
 };


### PR DESCRIPTION
As a way to reduce the amount of debug logging this module produces, we
only emit an unlink debug message if the unlink operation was succesful.

Also, as a better way to correlate unlink issues with a certain
drivelist call, we only report back the result of this module after the
unlink operation ended (sucessfully or not).

See: https://github.com/resin-io/etcher/pull/1600
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>