### PR TITLE
lsblk: Check `hotplug` to set `isRemovable`

### DIFF
--- a/lib/lsblk/json.js
+++ b/lib/lsblk/json.js
@@ -76,7 +76,7 @@ const transform = (data) => {
     const isSCSI = device.tran ? /^(sata|scsi|ata|ide|pci)$/i.test(device.tran) : null;
     const isUSB = device.tran ? /^(usb)$/i.test(device.tran) : null;
     const isReadOnly = Number(device.ro) === 1;
-    const isRemovable = Number(device.rm) === 1 || Boolean(isVirtual);
+    const isRemovable = Number(device.rm) === 1 || Number(device.hotplug) === 1 || Boolean(isVirtual);
     return {
       enumerator: 'lsblk:json',
       busType: (device.tran || 'UNKNOWN').toUpperCase(),

--- a/lib/lsblk/pairs.js
+++ b/lib/lsblk/pairs.js
@@ -132,7 +132,7 @@ const parse = (stdout) => {
     const isSCSI = device.tran ? /^(sata|scsi|ata|ide|pci)$/i.test(device.tran) : null;
     const isUSB = device.tran ? /^(usb)$/i.test(device.tran) : null;
     const isReadOnly = Number(device.ro) === 1;
-    const isRemovable = Number(device.rm) === 1 || Boolean(isVirtual);
+    const isRemovable = Number(device.rm) === 1 || Number(device.hotplug) === 1 || Boolean(isVirtual);
 
     return {
       enumerator: 'lsblk:pairs',


### PR DESCRIPTION
This adds a check for the `hotplug` property in `lsblk`'s output, which
fixes SD-cards not being detected as removable on some Linux distros

Change-type: patch
Connects to: #303
Signed-off-by: Jonas Hermsmeier <jhermsmeier@gmail.com>